### PR TITLE
Implement new interface for generalized getproperty (`@generated`)

### DIFF
--- a/ext/SatelliteToolboxTransformationsExt.jl
+++ b/ext/SatelliteToolboxTransformationsExt.jl
@@ -2,17 +2,17 @@ module SatelliteToolboxTransformationsExt
 
 using SatelliteToolboxTransformations: SatelliteToolboxTransformations, ecef_to_geodetic, geodetic_to_ecef
 using SatelliteToolboxBase: SatelliteToolboxBase, Ellipsoid, WGS84_ELLIPSOID
-using SatcomCoordinates: SatcomCoordinates, change_numbertype, raw_nt, constructor_without_checks, to_svector, asdeg, to_meters, ECEF, LLA
+using SatcomCoordinates: SatcomCoordinates, change_numbertype, normalized_properties, constructor_without_checks, normalized_svector, asdeg, to_meters, ECEF, LLA
 
 function SatelliteToolboxTransformations.ecef_to_geodetic(ecef::ECEF{T}; ellipsoid::Ellipsoid=WGS84_ELLIPSOID) where T <: AbstractFloat 
     ellipsoid = change_numbertype(T, ellipsoid)
-    lat,lon,alt = ecef_to_geodetic(to_svector(ecef); ellipsoid)
+    lat,lon,alt = ecef_to_geodetic(normalized_svector(ecef); ellipsoid)
     return constructor_without_checks(LLA{T}, asdeg(lat), asdeg(lon), to_meters(alt))
 end
 
 function SatelliteToolboxTransformations.geodetic_to_ecef(lla::LLA{T}; ellipsoid::Ellipsoid=WGS84_ELLIPSOID) where T
     ellipsoid = change_numbertype(T, ellipsoid)
-	(;lat, lon, alt) = raw_nt(lla)
+	(;lat, lon, alt) = normalized_properties(lla)
     ecef = geodetic_to_ecef(lat,lon,alt;ellipsoid) |> ECEF
     return ecef
 end

--- a/src/functions/geocentric.jl
+++ b/src/functions/geocentric.jl
@@ -53,7 +53,7 @@ end
 function Random.rand(rng::AbstractRNG, ::Random.SamplerType{E}) where E <: Union{ECI, ECEF}
     C = enforce_numbertype(E)
     T = numbertype(C)
-    p = rand(rng, PointingVersor{T}) |> to_svector
+    p = rand(rng, PointingVersor{T}) |> normalized_svector
     x, y, z = p * (7e6 * ((1 + rand(rng)) * u"m"))
     constructor_without_checks(C, x, y, z)
 end

--- a/src/functions/pointing_offsets.jl
+++ b/src/functions/pointing_offsets.jl
@@ -17,20 +17,11 @@ function (::Type{TPO})(args...) where TPO <: ThetaPhiOffset
 end
 
 ##### Base.getproperty #####
-function Base.getproperty(uv::UVOffset, s::Symbol)
-    inner = getfield(uv, :inner)
-    s === :inner && return inner
-    getproperty(inner, s)
-end
-function Base.getproperty(tp::ThetaPhiOffset, s::Symbol)
-    inner = getfield(tp, :inner)
-    s === :inner && return inner
-    getproperty(inner, s)
-end
+property_aliases(::Type{<:UVOffset}) = property_aliases(UV)
+property_aliases(::Type{<:ThetaPhiOffset}) = property_aliases(ThetaPhi)
 
-##### Base.isnan #####
-Base.isnan(uv::UVOffset) = return isnan(uv.inner)
-Base.isnan(tp::ThetaPhiOffset) = return isnan(tp.inner)
+##### raw_properties #####
+raw_properties(po::AbstractPointingOffset) = raw_properties(getfield(po, :inner))
 
 ##### Basic Operations #####
 function Base.:(-)(uv1::UV, uv2::UV) 
@@ -71,8 +62,8 @@ offset.theta ≈ Δθ
 See also: [`add_angular_offset`](@ref), [`get_angular_offset`](@ref)
 """
 function get_angular_distance(p₁::AbstractPointing, p₂::AbstractPointing)
-	p₁_xyz = convert(PointingVersor, p₁) |> to_svector
-	p₂_xyz = convert(PointingVersor, p₂) |> to_svector
+	p₁_xyz = convert(PointingVersor, p₁) |> normalized_svector
+	p₂_xyz = convert(PointingVersor, p₂) |> normalized_svector
 	return acos(min(p₁_xyz'p₂_xyz, 1)) |> asdeg
 end
 
@@ -153,7 +144,7 @@ See also: [`add_angular_offset`](@ref)
 """
 function get_angular_offset(p₁::AbstractPointing, p₂::AbstractPointing)
 	R = angle_offset_rotation(convert(ThetaPhi, p₁)) # We take p₁ as reference
-	p₂_xyz = convert(PointingVersor, p₂) |> to_svector # We create the 3D vector corresponding to p₂
+	p₂_xyz = convert(PointingVersor, p₂) |> normalized_svector # We create the 3D vector corresponding to p₂
 	# Check the comments in `angle_offset_rotation` and the link therein to understand this line
 	x, y, z = R' * p₂_xyz
     out = constructor_without_checks(enforce_numbertype(PointingVersor, x), x, y, z)
@@ -207,7 +198,7 @@ See also: [`get_angular_offset`](@ref), [`get_angular_distance`](@ref), [`ThetaP
 function add_angular_offset(::Type{O}, p₀::P, offset_angles::ThetaPhi) where {O <: AbstractPointing, P <: AbstractPointing}
 	θφ_in = convert(ThetaPhi, p₀)
 	R = angle_offset_rotation(θφ_in)
-	perturbation = convert(PointingVersor, offset_angles) |> to_svector
+	perturbation = convert(PointingVersor, offset_angles) |> normalized_svector
 	# Check the comments in `angle_offset_rotation` and the link therein to understand this line
 	x,y,z = R * perturbation
     out_direction = constructor_without_checks(enforce_numbertype(PointingVersor, x), x, y, z)
@@ -224,4 +215,4 @@ PlutoShowHelpers.repl_summary(p::AbstractPointingOffset) = shortname(p.inner) * 
 
 PlutoShowHelpers.show_namedtuple(p::UVOffset) = show_namedtuple(p.inner)
 
-PlutoShowHelpers.show_namedtuple(p::ThetaPhiOffset) = map(DualDisplayAngle, raw_nt(p.inner))
+PlutoShowHelpers.show_namedtuple(p::ThetaPhiOffset) = map(DualDisplayAngle, normalized_properties(p.inner))

--- a/src/functions/topocentric.jl
+++ b/src/functions/topocentric.jl
@@ -67,7 +67,7 @@ end
 function _convert_different(::Type{A}, src::S) where {A <: AER, S <: Union{ENU, NED}}
     C = enforce_numbertype(A, src)
     enu = convert(ENU, src)
-    sv = to_svector(enu)
+    sv = normalized_svector(enu)
     r = norm(sv) * u"m"
     (;az, el) = convert(AzEl, PointingVersor(sv...))
     constructor_without_checks(C, az, el, r)
@@ -78,7 +78,7 @@ function _convert_different(::Type{S}, src::A) where {S <: Union{ENU, NED}, A <:
     (; az, el, r) = src
     ae = constructor_without_checks(AzEl{T}, az, el)
     p = convert(PointingVersor, ae)
-    (;x, y, z) = to_svector(p) .* r
+    (;x, y, z) = normalized_svector(p) .* r
     enu = constructor_without_checks(ENU{T}, x, y, z)
     convert(S, enu)
 end
@@ -89,4 +89,4 @@ function Base.isapprox(c1::TopocentricPosition, c2::TopocentricPosition; kwargs.
     e2 = convert(ENU, c2)
     isapprox(e1, e2; kwargs...)
 end
-Base.isapprox(c1::ENU, c2::ENU; kwargs...) = isapprox(to_svector(c1), to_svector(c2); kwargs...)
+Base.isapprox(c1::ENU, c2::ENU; kwargs...) = isapprox(normalized_svector(c1), normalized_svector(c2); kwargs...)

--- a/src/functions/transforms.jl
+++ b/src/functions/transforms.jl
@@ -46,7 +46,7 @@ TransformsBase.parameters(t::AbstractCRSTransform) = getfields(t)
 
 # Fallback apply, actual methods should be defined taking StaticVector as reference input if not for special cases
 function TransformsBase.apply(t::AbstractCRSTransform, coords::LocalCartesian) 
-    new_coords, _ = apply(t, to_svector(coords))
+    new_coords, _ = apply(t, normalized_svector(coords))
     return LocalCartesian(new_coords), nothing
 end
 
@@ -64,12 +64,12 @@ TransformsBase.apply(t::AbstractCRSRotation, coords::StaticVector) =
 # Affine transform
 function TransformsBase.apply(t::AbstractAffineCRSTransform, coords::StaticVector)
     rotated, _ = apply(rotation(t), coords)
-    new_coords = rotated + to_svector(origin(t))
+    new_coords = rotated + normalized_svector(origin(t))
     return new_coords, nothing
 end
 
 function TransformsBase.apply(t::InverseTransform{<:Any, <:AbstractAffineCRSTransform}, coords::StaticVector)
-    shifted = coords - to_svector(origin(t))
+    shifted = coords - normalized_svector(origin(t))
     rotated, _ = apply(rotation(t), shifted)
     return rotated, nothing
 end

--- a/src/types/type_aliases.jl
+++ b/src/types/type_aliases.jl
@@ -51,3 +51,10 @@ const ForwardOrInverse{F <: AbstractCRSTransform} = Union{F, InverseTransform{<:
 Union representing the types defined and exported by this package, which always have a numbertype as first parameter.
 """
 const WithNumbertype{T} = Union{AbstractSatcomCoordinate{T}, AbstractCRSTransform{T}}
+
+# These are const variables used to overload getproperty for specific fields
+const THETA_ALIASES = (:θ, :theta, :t)
+const PHI_ALIASES = (:φ, :ϕ, :phi, :p)
+const AZIMUTH_ALIASES = (:az, :azimuth)
+const ELEVATION_ALIASES = (:el, :elevation)
+const DISTANCE_ALIASES = (:r, :distance, :range)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -174,6 +174,3 @@ function normalize_value(val::PS)
         val
     end
 end
-
-raw_nt(x) = normalized_properties(x)
-to_svector(x) = normalized_svector(x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -108,31 +108,60 @@ wrap_spherical_angles(α::ValidAngle, β::ValidAngle, ::Type{T}) where T <: Unio
 wrap_spherical_angles(p::Point2D, ::Type{T}) where T <: Union{ThetaPhi, AzOverEl, ElOverAz} = wrap_spherical_angles(p[1], p[2], T)
 
 """
-    to_svector(coord::AbstractSatcomCoordinate)
+    normalized_svector(coord::AbstractSatcomCoordinate)
 
 Generate the unitless SVector containing the _normalized_ fields of the provided coordinate.
 
 !!! note
     By _normalized_ we mean that fields containing Uniftul quantities are stripped of their units and in the case of `Deg` fields, they are converted to radians as trig functions are faster for radians inputs.
 
-See also [`raw_nt`](@ref)
+See also [`normalized_properties`](@ref)
 """
-function to_svector(coords::C) where C <: AbstractSatcomCoordinate
-    raw_nt(coords) |> Tuple |> SVector{3, numbertype(C)}
+function normalized_svector(coords::C) where C <: AbstractSatcomCoordinate
+    normalized_properties(coords) |> Tuple |> SVector{3, numbertype(C)}
 end
 
 """
-    raw_nt(coords::AbstractSatcomCoordinate)
+    normalized_properties(coords::AbstractSatcomCoordinate)
 Generated a NamedTuple from the provided Object which has the same names as the object fields but contains _normalized_ values of its fields
 
 !!! note
     By _normalized_ we mean that fields containing Uniftul quantities are stripped of their units and in the case of `Deg` fields, they are converted to radians as trig functions are faster for radians inputs.
 
-See also [`to_svector`](@ref)
+See also [`raw_properties`](@ref), [`svector`](@ref)
 """
-function raw_nt(coords::C) where C <: AbstractSatcomCoordinate
-    nt = @inline getfields(coords)
-    map(normalize_value, nt)
+function normalized_properties(coords::C) where C <: AbstractSatcomCoordinate
+    map(normalize_value, raw_properties(coords))
+end
+
+"""
+    raw_properties(c::AbstractSatcomCoordinate)
+
+Generate a NamedTuple from the provided Object which should be used for iteration over the object `properties`. All of the properties of an `AbstractSatcomCoordinate` should be Numbers or Quantities.
+
+This defaults to the `getfields` function from `ConstructionsBase.jl` module but should be overloaded for specific types that encapsulate other coordinates as fields (e.g. `GeneralizedSpherical`).
+
+See also [`normalized_properties`](@ref), [`svector`](@ref)
+"""
+raw_properties(c::AbstractSatcomCoordinate) = getfields(c)
+
+"""
+    property_aliases(T::Type)
+
+This function should return a NamedTuple whose keys shall be consistent with the keys of the NamedTuple returned by [`raw_properties`](@ref) and whose values should be Tuples of Symbols identifying alternatives names (i.e. aliases) for the specific property names to be used within the `Base.getproperty` method for objects of type `T`.
+
+For example, the `property_aliases` function for `ThetaPhi` objects returns the following NamedTuple:
+```julia
+property_aliases(ThetaPhi) == (;
+    θ = (:θ, :t, :theta),
+    φ = (:φ, :ϕ, :p, :phi)
+)
+```
+"""
+function property_aliases(T::Type)
+    fn = fieldnames(T)
+    vals = ntuple(i -> (fn[i], ), length(fn))
+    return NamedTuple{fn}(vals)
 end
 
 # Internal function used to strip unit from field values and convert degress to radians
@@ -145,3 +174,6 @@ function normalize_value(val::PS)
         val
     end
 end
+
+raw_nt(x) = normalized_properties(x)
+to_svector(x) = normalized_svector(x)

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -1,6 +1,6 @@
 @testsnippet setup_extensions begin
     using SatcomCoordinates
-    using SatcomCoordinates: raw_nt, to_svector
+    using SatcomCoordinates: normalized_properties, normalized_svector
     using Test
     using TestAllocations
 end
@@ -40,10 +40,10 @@ end
     @test ecef_to_geodetic(rand(ECEF{Float32}), ellipsoid=e) isa LLA{Float32}
 
     # Some test for specific values
-    ecef = geodetic_to_ecef(LLA(0,0,0)) |> to_svector
+    ecef = geodetic_to_ecef(LLA(0,0,0)) |> normalized_svector
     @test ecef ≈ [WGS84_ELLIPSOID.a, 0, 0]
 
-    ecef = geodetic_to_ecef(LLA(90,0,0)) |> to_svector
+    ecef = geodetic_to_ecef(LLA(90,0,0)) |> normalized_svector
     @test ecef ≈ [0, 0, WGS84_ELLIPSOID.b]
 
     # Test some random fwd and rtn equivalence

--- a/test/geocentric.jl
+++ b/test/geocentric.jl
@@ -1,5 +1,5 @@
 @testsnippet setup_geocentric begin
-    using SatcomCoordinates: numbertype, to_svector, raw_nt, @u_str
+    using SatcomCoordinates: numbertype, normalized_svector, normalized_properties, @u_str
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes

--- a/test/local.jl
+++ b/test/local.jl
@@ -1,6 +1,6 @@
 @testsnippet setup_local begin
     using SatcomCoordinates
-    using SatcomCoordinates: numbertype, to_svector, raw_nt, @u_str, has_pointingtype, pointing_type
+    using SatcomCoordinates: numbertype, normalized_svector, normalized_properties, @u_str, has_pointingtype, pointing_type
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes
@@ -34,8 +34,8 @@ end
     end
 
     c1, c2 = rand(LocalCartesian, 2)
-    @test to_svector(c1 + c2) == to_svector(c1) + to_svector(c2)
-    @test to_svector(c1 - c2) == to_svector(c1) - to_svector(c2)
+    @test normalized_svector(c1 + c2) == normalized_svector(c1) + normalized_svector(c2)
+    @test normalized_svector(c1 - c2) == normalized_svector(c1) - normalized_svector(c2)
 
     c3 = rand(LocalCartesian{Float32})
     @test c1 + c3 isa LocalCartesian{Float64}
@@ -72,8 +72,8 @@ end
         @test @nallocs(getproperty(rand(Spherical), :theta)) == 0
         @test @nallocs(getproperty(rand(Spherical), :phi)) == 0
 
-        @test @nallocs(raw_nt(rand(Spherical))) == 0
-        @test @nallocs(raw_nt(rand(AzElDistance))) == 0
+        @test @nallocs(normalized_properties(rand(Spherical))) == 0
+        @test @nallocs(normalized_properties(rand(AzElDistance))) == 0
     end
 
     @test GeneralizedSpherical{Float32}(rand(ThetaPhi), rand()) isa Spherical{Float32}
@@ -96,7 +96,7 @@ end
     @test pointing_type(GeneralizedSpherical{Float64, ThetaPhi{Float64}}) == ThetaPhi{Float64}
 
     p = rand(Spherical)
-    @test raw_nt(p) isa NamedTuple{(:θ, :φ, :r), Tuple{Float64, Float64, Float64}}
+    @test normalized_properties(p) isa NamedTuple{(:θ, :φ, :r), Tuple{Float64, Float64, Float64}}
 
     for PT in (ThetaPhi, AzEl, ElOverAz, AzOverEl)
         gs = rand(GeneralizedSpherical{Float64, PT{Float64}})

--- a/test/pointing.jl
+++ b/test/pointing.jl
@@ -1,5 +1,5 @@
 @testsnippet setup_pointing begin
-    using SatcomCoordinates: numbertype, to_svector
+    using SatcomCoordinates: numbertype, normalized_svector
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes
@@ -8,7 +8,7 @@ end
 
 @testitem "PointingVersor" setup=[setup_pointing] begin
     p = PointingVersor(rand(3)...)
-    @test norm(to_svector(p)) ≈ 1
+    @test norm(normalized_svector(p)) ≈ 1
 
     @test_throws "do not have a property" rand(PointingVersor).q
 
@@ -23,7 +23,7 @@ end
     p = PointingVersor((0.0, 0, 1f0))
     @test p.z == 1.0 && p.z isa Float64
 
-    @test to_svector(-p) == -to_svector(p)
+    @test normalized_svector(-p) == -normalized_svector(p)
 
     # Test some randomness properties
     @testset "rand" begin
@@ -192,7 +192,7 @@ end
         @test p.el == p.elevation == 2°
         @test p.az isa Deg{Float64}
 
-        @test_throws "`$P` do not have a property" rand(P).q
+        @test_throws "do not have a property" rand(P).q
 
         # Test constructors with tuple or SVector
         @test P(1,2) == P((1,2)) == P(SVector(1,2))

--- a/test/pointing_offset.jl
+++ b/test/pointing_offset.jl
@@ -1,6 +1,6 @@
 @testsnippet setup_pointing_offsets begin
     using SatcomCoordinates
-    using SatcomCoordinates: numbertype, to_svector, raw_nt, @u_str, has_pointingtype, pointing_type, rotation, origin, UVOffset, ThetaPhiOffset
+    using SatcomCoordinates: numbertype, normalized_svector, normalized_properties, @u_str, has_pointingtype, pointing_type, rotation, origin, UVOffset, ThetaPhiOffset
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes

--- a/test/topocentric.jl
+++ b/test/topocentric.jl
@@ -1,5 +1,5 @@
 @testsnippet setup_topocentric begin
-    using SatcomCoordinates: numbertype, to_svector, raw_nt, @u_str
+    using SatcomCoordinates: numbertype, normalized_svector, normalized_properties, @u_str
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes
@@ -28,8 +28,8 @@ end
         @test p1 ≈ convert(P{Float32}, p1)
 
         c1, c2 = rand(P, 2)
-        @test to_svector(c1 + c2) == to_svector(c1) + to_svector(c2)
-        @test to_svector(c1 - c2) == to_svector(c1) - to_svector(c2)
+        @test normalized_svector(c1 + c2) == normalized_svector(c1) + normalized_svector(c2)
+        @test normalized_svector(c1 - c2) == normalized_svector(c1) - normalized_svector(c2)
 
         c3 = rand(P{Float32})
         @test c1 + c3 isa P{Float64}

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -1,6 +1,6 @@
 @testsnippet setup_transforms begin
     using SatcomCoordinates
-    using SatcomCoordinates: numbertype, to_svector, raw_nt, @u_str, has_pointingtype, pointing_type, rotation, origin, AbstractCRSRotation
+    using SatcomCoordinates: numbertype, normalized_svector, normalized_properties, @u_str, has_pointingtype, pointing_type, rotation, origin, AbstractCRSRotation
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes


### PR DESCRIPTION
This PR adds to the SatcomCoordinate interface two new functions:
- `raw_properties`
- `property_aliases`
and renames two other functions:
- `to_svector` -> `normalized_svector`
- `raw_nt` -> `normalized_properties`

Now the `Base.getproperty` function is a `@generated` function that exploits the definition of `property_aliases` and `raw_properties` to render new complex abstract coordinates easier to implement