### PR TITLE
Refactor code to have coordinates store a single SVector as field

### DIFF
--- a/ext/SatelliteToolboxTransformationsExt.jl
+++ b/ext/SatelliteToolboxTransformationsExt.jl
@@ -2,12 +2,12 @@ module SatelliteToolboxTransformationsExt
 
 using SatelliteToolboxTransformations: SatelliteToolboxTransformations, ecef_to_geodetic, geodetic_to_ecef
 using SatelliteToolboxBase: SatelliteToolboxBase, Ellipsoid, WGS84_ELLIPSOID
-using SatcomCoordinates: SatcomCoordinates, change_numbertype, raw_properties, constructor_without_checks, raw_svector, asdeg, to_meters, ECEF, LLA
+using SatcomCoordinates: SatcomCoordinates, change_numbertype, raw_properties, constructor_without_checks, raw_svector, ECEF, LLA, SVector
 
 function SatelliteToolboxTransformations.ecef_to_geodetic(ecef::ECEF{T}; ellipsoid::Ellipsoid=WGS84_ELLIPSOID) where T <: AbstractFloat 
     ellipsoid = change_numbertype(T, ellipsoid)
     lat,lon,alt = ecef_to_geodetic(raw_svector(ecef); ellipsoid)
-    return constructor_without_checks(LLA{T}, asdeg(lat), asdeg(lon), to_meters(alt))
+    return constructor_without_checks(LLA{T}, SVector{3, T}(lat, lon, alt))
 end
 
 function SatelliteToolboxTransformations.geodetic_to_ecef(lla::LLA{T}; ellipsoid::Ellipsoid=WGS84_ELLIPSOID) where T

--- a/ext/SatelliteToolboxTransformationsExt.jl
+++ b/ext/SatelliteToolboxTransformationsExt.jl
@@ -2,17 +2,17 @@ module SatelliteToolboxTransformationsExt
 
 using SatelliteToolboxTransformations: SatelliteToolboxTransformations, ecef_to_geodetic, geodetic_to_ecef
 using SatelliteToolboxBase: SatelliteToolboxBase, Ellipsoid, WGS84_ELLIPSOID
-using SatcomCoordinates: SatcomCoordinates, change_numbertype, normalized_properties, constructor_without_checks, normalized_svector, asdeg, to_meters, ECEF, LLA
+using SatcomCoordinates: SatcomCoordinates, change_numbertype, raw_properties, constructor_without_checks, raw_svector, asdeg, to_meters, ECEF, LLA
 
 function SatelliteToolboxTransformations.ecef_to_geodetic(ecef::ECEF{T}; ellipsoid::Ellipsoid=WGS84_ELLIPSOID) where T <: AbstractFloat 
     ellipsoid = change_numbertype(T, ellipsoid)
-    lat,lon,alt = ecef_to_geodetic(normalized_svector(ecef); ellipsoid)
+    lat,lon,alt = ecef_to_geodetic(raw_svector(ecef); ellipsoid)
     return constructor_without_checks(LLA{T}, asdeg(lat), asdeg(lon), to_meters(alt))
 end
 
 function SatelliteToolboxTransformations.geodetic_to_ecef(lla::LLA{T}; ellipsoid::Ellipsoid=WGS84_ELLIPSOID) where T
     ellipsoid = change_numbertype(T, ellipsoid)
-	(;lat, lon, alt) = normalized_properties(lla)
+	(;lat, lon, alt) = raw_properties(lla)
     ecef = geodetic_to_ecef(lat,lon,alt;ellipsoid) |> ECEF
     return ecef
 end

--- a/src/SatcomCoordinates.jl
+++ b/src/SatcomCoordinates.jl
@@ -1,14 +1,14 @@
 module SatcomCoordinates
 
 using BasicTypes: BasicTypes, constructor_without_checks, to_degrees, to_meters, Met, Deg, Rad, UnitfulAngleQuantity, ValidAngle, Point2D, Point3D, Point, PS, ValidDistance, to_radians, basetype, asdeg, stripdeg, Length
-using ConstructionBase: ConstructionBase, getproperties
+using ConstructionBase: ConstructionBase, getproperties, getfields
 using StaticArrays: StaticArrays, FieldVector, SVector, @SVector, SA, StaticMatrix, StaticVector
 using LinearAlgebra: LinearAlgebra, normalize, norm
 using PlutoShowHelpers: PlutoShowHelpers, DefaultShowOverload, HideWhenCompact, DualDisplayAngle, DisplayLength, InsidePluto, OutsidePluto, HideWhenFull, Ellipsis, repl_summary, shortname, longname, show_namedtuple
 using Random: Random, SamplerType, AbstractRNG
 using Rotations: Rotations, Rotation, nearest_rotation, RotMatrix3
 using TransformsBase: TransformsBase, Transform, Identity, isinvertible, isrevertible, inverse, apply
-using Unitful: Unitful, Quantity, ustrip, rad, @u_str, °, km, dimension
+using Unitful: Unitful, Quantity, ustrip, rad, @u_str, °, km, Units
 
 # From deps
 export °, km, @u_str # From Unitful
@@ -51,10 +51,10 @@ export get_angular_distance, get_angular_offset, add_angular_offset
 include("functions/geocentric.jl")
 include("functions/topocentric.jl")
 include("functions/local.jl")
-# include("functions/transforms.jl")
-# public origin, rotation
+include("functions/transforms.jl")
+public origin, rotation
 
-# include("functions/fieldvalues.jl")
+include("functions/fieldvalues.jl")
 
 include("utils.jl")
 export numbertype, enforce_numbertype, has_numbertype, change_numbertype, default_numbertype, property_aliases, raw_properties, raw_svector, raw_properties

--- a/src/SatcomCoordinates.jl
+++ b/src/SatcomCoordinates.jl
@@ -8,7 +8,7 @@ using PlutoShowHelpers: PlutoShowHelpers, DefaultShowOverload, HideWhenCompact, 
 using Random: Random, SamplerType, AbstractRNG
 using Rotations: Rotations, Rotation, nearest_rotation, RotMatrix3
 using TransformsBase: TransformsBase, Transform, Identity, isinvertible, isrevertible, inverse, apply
-using Unitful: Unitful, Quantity, ustrip, rad, @u_str, °, km, Units
+using Unitful: Unitful, Quantity, ustrip, rad, @u_str, °, km, Units, NoUnits
 
 # From deps
 export °, km, @u_str # From Unitful
@@ -16,7 +16,7 @@ export to_degrees, to_meters # From BasicTypes
 export Identity # From TransformsBase
 
 include("types/abstract_types.jl")
-export AbstractSatcomCoordinate, CartesianPosition, LengthCartesian, AngularPointing, AbstractPointing, AbstractCRSTransform, AbstractFieldValue, AbstractPosition
+export AbstractSatcomCoordinate, AngularPointing, AbstractPointing, AbstractCRSTransform, AbstractFieldValue, AbstractPosition
 public AbstractPointingOffset
 
 include("types/traits.jl")
@@ -57,7 +57,7 @@ public origin, rotation
 include("functions/fieldvalues.jl")
 
 include("utils.jl")
-export numbertype, enforce_numbertype, has_numbertype, change_numbertype, default_numbertype, property_aliases, raw_properties, raw_svector, raw_properties
+export numbertype, enforce_numbertype, has_numbertype, change_numbertype, default_numbertype, raw_properties, raw_svector, raw_properties
 
 include("functions/fallbacks.jl")
 

--- a/src/SatcomCoordinates.jl
+++ b/src/SatcomCoordinates.jl
@@ -50,7 +50,7 @@ include("functions/pointing.jl")
 
 # include("functions/geocentric.jl")
 # include("functions/topocentric.jl")
-# include("functions/local.jl")
+include("functions/local.jl")
 # include("functions/transforms.jl")
 # public origin, rotation
 

--- a/src/SatcomCoordinates.jl
+++ b/src/SatcomCoordinates.jl
@@ -24,14 +24,14 @@ include("types/traits.jl")
 include("types/pointing.jl")
 export PointingVersor, UV, ThetaPhi, AzEl, AzOverEl, ElOverAz
 
-# include("types/pointing_offsets.jl") 
-# public UVOffset, ThetaPhiOffset 
+include("types/pointing_offsets.jl") 
+public PointingOffset
 
-# include("types/geocentric.jl") 
-# export ECEF, ECI, LLA 
+include("types/geocentric.jl") 
+export ECEF, ECI, LLA 
 
-# include("types/topocentric.jl") 
-# export ENU, NED, AER 
+include("types/topocentric.jl") 
+export ENU, NED, AER 
 
 include("types/local.jl") 
 export LocalCartesian, GeneralizedSpherical 
@@ -45,11 +45,11 @@ export Spherical, AzElDistance
 include("functions/traits.jl")
 
 include("functions/pointing.jl")
-# include("functions/pointing_offsets.jl")
-# export get_angular_distance, get_angular_offset, add_angular_offset
+include("functions/pointing_offsets.jl")
+export get_angular_distance, get_angular_offset, add_angular_offset
 
-# include("functions/geocentric.jl")
-# include("functions/topocentric.jl")
+include("functions/geocentric.jl")
+include("functions/topocentric.jl")
 include("functions/local.jl")
 # include("functions/transforms.jl")
 # public origin, rotation

--- a/src/SatcomCoordinates.jl
+++ b/src/SatcomCoordinates.jl
@@ -1,7 +1,7 @@
 module SatcomCoordinates
 
 using BasicTypes: BasicTypes, constructor_without_checks, to_degrees, to_meters, Met, Deg, Rad, UnitfulAngleQuantity, ValidAngle, Point2D, Point3D, Point, PS, ValidDistance, to_radians, basetype, asdeg, stripdeg, Length
-using ConstructionBase: ConstructionBase, getfields
+using ConstructionBase: ConstructionBase, getproperties
 using StaticArrays: StaticArrays, FieldVector, SVector, @SVector, SA, StaticMatrix, StaticVector
 using LinearAlgebra: LinearAlgebra, normalize, norm
 using PlutoShowHelpers: PlutoShowHelpers, DefaultShowOverload, HideWhenCompact, DualDisplayAngle, DisplayLength, InsidePluto, OutsidePluto, HideWhenFull, Ellipsis, repl_summary, shortname, longname, show_namedtuple
@@ -19,41 +19,45 @@ include("types/abstract_types.jl")
 export AbstractSatcomCoordinate, CartesianPosition, LengthCartesian, AngularPointing, AbstractPointing, AbstractCRSTransform, AbstractFieldValue, AbstractPosition
 public AbstractPointingOffset
 
+include("types/traits.jl")
+
 include("types/pointing.jl")
 export PointingVersor, UV, ThetaPhi, AzEl, AzOverEl, ElOverAz
 
-include("types/pointing_offsets.jl")
-public UVOffset, ThetaPhiOffset
+# include("types/pointing_offsets.jl") 
+# public UVOffset, ThetaPhiOffset 
 
-include("types/geocentric.jl")
-export ECEF, ECI, LLA
+# include("types/geocentric.jl") 
+# export ECEF, ECI, LLA 
 
-include("types/topocentric.jl")
-export ENU, NED, AER
+# include("types/topocentric.jl") 
+# export ENU, NED, AER 
 
-include("types/local.jl")
-export LocalCartesian, GeneralizedSpherical
+include("types/local.jl") 
+export LocalCartesian, GeneralizedSpherical 
 
-include("types/transforms.jl")
-export CRSRotation, BasicCRSTransform, InverseTransform
+include("types/transforms.jl") 
+export CRSRotation, BasicCRSTransform, InverseTransform 
 
-include("types/type_aliases.jl")
-export GeocentricPosition, TopocentricPosition, GenericLocalPosition, Spherical, AzElDistance
+include("types/type_aliases.jl") 
+export Spherical, AzElDistance
+
+include("functions/traits.jl")
 
 include("functions/pointing.jl")
-include("functions/pointing_offsets.jl")
-export get_angular_distance, get_angular_offset, add_angular_offset
+# include("functions/pointing_offsets.jl")
+# export get_angular_distance, get_angular_offset, add_angular_offset
 
-include("functions/geocentric.jl")
-include("functions/topocentric.jl")
-include("functions/local.jl")
-include("functions/transforms.jl")
-public origin, rotation
+# include("functions/geocentric.jl")
+# include("functions/topocentric.jl")
+# include("functions/local.jl")
+# include("functions/transforms.jl")
+# public origin, rotation
 
-include("functions/fieldvalues.jl")
+# include("functions/fieldvalues.jl")
 
 include("utils.jl")
-export numbertype, enforce_numbertype, has_numbertype, change_numbertype, default_numbertype, property_aliases, raw_properties, normalized_svector, normalized_properties
+export numbertype, enforce_numbertype, has_numbertype, change_numbertype, default_numbertype, property_aliases, raw_properties, raw_svector, raw_properties
 
 include("functions/fallbacks.jl")
 

--- a/src/functions/fallbacks.jl
+++ b/src/functions/fallbacks.jl
@@ -1,49 +1,82 @@
-# Generic NaN constructor for all SatcomCoordinate types
-(::Type{C})(::Val{NaN}) where C <: AbstractSatcomCoordinate = constructor_without_checks(enforce_numbertype(C), NaN, NaN, NaN)
-(::Type{C})(::Val{NaN}) where C <: LengthCartesian = constructor_without_checks(enforce_numbertype(C), NaN * u"m", NaN * u"m", NaN * u"m")
-(::Type{C})(::Val{NaN}) where C <: AngleAngleDistance = constructor_without_checks(enforce_numbertype(C), NaN * u"°", NaN * u"°", NaN * u"m")
+# # Addition, subtraction and sign inversion
+# Base.:(-)(c::C) where C <: CartesianPosition = constructor_without_checks(C, -c.x, -c.y, -c.z)
+# function Base.:(+)(c1::C1, c2::C2) where {C1 <: CartesianPosition, C2 <: CartesianPosition} 
+#     C = basetype(C1)
+#     C == basetype(C2) || throw(ArgumentError("Cannot add coordinates of different types: $C1 and $C2"))
+#     T = promote_type(numbertype(C1), numbertype(C2))
+#     constructor_without_checks(C{T}, c1.x + c2.x, c1.y + c2.y, c1.z + c2.z)
+# end
+# Base.:(-)(c1::C1, c2::C2) where {C1 <: CartesianPosition, C2 <: CartesianPosition} = c1 + (-c2)
 
-# Generic Tuple/SVector constructor for all LengthCartesian types
-(::Type{P})(pt::Point{3, ValidDistance}) where P <: LengthCartesian = P(pt...)
+#### Properties ####
 
-# Generic 3-arg constructor for LengthCartesian types
-function (::Type{P})(xyz::Vararg{ValidDistance, 3}) where P <: LengthCartesian
-    PP = enforce_numbertype(P, default_numbertype(xyz...))
-    any(isnan, xyz) && return PP(Val{NaN}())
-    x, y, z = map(to_meters, xyz)
-    constructor_without_checks(PP, x, y, z)
+Base.propertynames(p::AbstractSatcomCoordinate) = properties_names(typeof(p))
+
+properties_names(::Type{<:AbstractPosition{<:Any, 3}}) = (:x, :y, :z)
+
+ConstructionBase.getproperties(p::AbstractSatcomCoordinate) = raw_properties(p)
+# For positions we resort to a Trait to dispatch on whether it's Cartesian or AngleAngleDistance
+ConstructionBase.getproperties(p::AbstractPosition) = _position_properties(position_trait(p), p)
+
+_position_properties(::CartesianPositionTrait, p::AbstractPosition) = map(to_meters, raw_properties(p))
+function _position_properties(::SphericalPositionTrait, p::AbstractPosition{T, 3}) where T
+    a1, a2, r = raw_svector(p)
+    nms = propertynames(p)
+    return NamedTuple{nms}(asdeg(a1), asdeg(a2), to_meters(r))
 end
 
-# Addition, subtraction and sign inversion
-Base.:(-)(c::C) where C <: CartesianPosition = constructor_without_checks(C, -c.x, -c.y, -c.z)
-function Base.:(+)(c1::C1, c2::C2) where {C1 <: CartesianPosition, C2 <: CartesianPosition} 
-    C = basetype(C1)
-    C == basetype(C2) || throw(ArgumentError("Cannot add coordinates of different types: $C1 and $C2"))
-    T = promote_type(numbertype(C1), numbertype(C2))
-    constructor_without_checks(C{T}, c1.x + c2.x, c1.y + c2.y, c1.z + c2.z)
+function Base.getproperty(p::AbstractSatcomCoordinate, s::Symbol)
+    s in propertynames(p) || throw(ArgumentError("Property $s is not a valid property for objects of type $(typeof(p))"))
+    nt = getproperties(p)
+    return getproperty(nt, s)
 end
-Base.:(-)(c1::C1, c2::C2) where {C1 <: CartesianPosition, C2 <: CartesianPosition} = c1 + (-c2)
 
-# zero
-Base.zero(::Type{C}) where C <: CartesianPosition = constructor_without_checks(enforce_numbertype(C), map(to_meters, zero(SVector{3, Float64}))...)
+# This function should take as input independent 
+function construct_inner_svector end
+
+function construct_inner_svector(::Type{<:AbstractPosition{T, N}}, args::Vararg{Real, N}) where {T <: AbstractFloat, N}
+    return SVector{N, T}(args...)
+end
+
+svector_size(::Type{<:StaticVector{N}}) where N = N
+svector_size(T::Type{<:AbstractSatcomCoordinate}) = svector_size(fieldtypes(enforce_numbertype(T)) |> first)
+
+function (P::Type{<:AbstractSatcomCoordinate})(::Val{NaN})
+    PT = enforce_numbertype(P)
+    T = numbertype(PT)
+    N = svector_size(PT)
+    sv = ntuple(_ -> T(NaN), N) |> SVector{N, T}
+    return constructor_without_checks(PT, sv)
+end
+
+function (P::Type{<:AbstractSatcomCoordinate{<:Any, N}})(args::Vararg{Any, N}) where N
+    PT = enforce_numbertype(P, default_numbertype(args...))
+    any(isnan, args) && return PT(Val{NaN}())
+    v = construct_inner_svector(PT, args...)
+    return constructor_without_checks(PT, v)
+end
+(P::Type{<:AbstractSatcomCoordinate{<:Any, N}})(coords::Point{N}) where N = P(coords...)
+
+# # zero
+# Base.zero(::Type{C}) where C <: CartesianPosition = constructor_without_checks(enforce_numbertype(C), map(to_meters, zero(SVector{3, Float64}))...)
 
 # isnan
-Base.isnan(x::Union{AbstractSatcomCoordinate, AbstractFieldValue}) = any(isnan, normalized_properties(x))
+Base.isnan(x::Union{AbstractSatcomCoordinate, AbstractFieldValue}) = any(isnan, raw_properties(x))
 
-# isapprox
-function Base.isapprox(c1::C1, c2::C2; kwargs...) where {C1 <: CartesianPosition, C2 <: CartesianPosition}
-    basetype(C1) == basetype(C2) || throw(ArgumentError("Cannot compare coordinates of different types: $C1 and $C2"))
-    isapprox(normalized_svector(c1), normalized_svector(c2); kwargs...)
-end
+# # isapprox
+# function Base.isapprox(c1::C1, c2::C2; kwargs...) where {C1 <: CartesianPosition, C2 <: CartesianPosition}
+#     basetype(C1) == basetype(C2) || throw(ArgumentError("Cannot compare coordinates of different types: $C1 and $C2"))
+#     isapprox(raw_svector(c1), raw_svector(c2); kwargs...)
+# end
 
-# Rand for LengthCartesian
-function Random.rand(rng::AbstractRNG, ::Random.SamplerType{L}) where L <: LengthCartesian
-    C = enforce_numbertype(L)
-    T = numbertype(C)
-    p = rand(rng, PointingVersor{T}) |> normalized_svector
-    x, y, z = p * (1e3 * ((1 + rand(rng)) * u"m"))
-    constructor_without_checks(C, x, y, z)
-end
+# # Rand for LengthCartesian
+# function Random.rand(rng::AbstractRNG, ::Random.SamplerType{L}) where L <: LengthCartesian
+#     C = enforce_numbertype(L)
+#     T = numbertype(C)
+#     p = rand(rng, PointingVersor{T}) |> raw_svector
+#     x, y, z = p * (1e3 * ((1 + rand(rng)) * u"m"))
+#     constructor_without_checks(C, x, y, z)
+# end
 
 function Base.convert(::Type{C1}, c::C2) where {C1 <: AbstractSatcomCoordinate, C2 <: AbstractSatcomCoordinate}
     isnan(c) && return enforce_numbertype(C1, c)(Val{NaN}())
@@ -59,8 +92,9 @@ function _convert_same(::Type{C}, c::C) where C <: AbstractSatcomCoordinate
 end
 function _convert_same(::Type{C1}, c::C2) where {C1 <: AbstractSatcomCoordinate, C2 <: AbstractSatcomCoordinate}
     has_numbertype(C1) || return c # If numbertype was specified, we don't need to convert
-    vals = @inline getfields(c)
-    return constructor_without_checks(C1, vals...)
+    T = numbertype(C1)
+    sv = change_numbertype(T, raw_svector(c))
+    return constructor_without_checks(C1, sv)
 end
 
 function _convert_different(::Type{C1}, c::C2) where {C1 <: AbstractSatcomCoordinate, C2 <: AbstractSatcomCoordinate}
@@ -105,20 +139,6 @@ change_numbertype(::Type{T}) where T <: AbstractFloat = return Base.Fix1(change_
 # Generic fallback for own types calling convert
 change_numbertype(::Type{T}, c::C) where {T <: AbstractFloat, C <: WithNumbertype} = return convert(basetype(C){T}, c)
 
-# Base.getproperty fallback with generated function (to have faster getproperty)
-@generated function Base.getproperty(c::Union{AbstractSatcomCoordinate, AbstractFieldValue}, s::Symbol)
-    aliases = property_aliases(c)
-    block = Expr(:block)
-    args = block.args
-    push!(args, :(nt = raw_properties(c)))
-    push!(args, :(s in $(fieldnames(c)) && return getfield(c, s)))
-    for (k, v) in pairs(aliases)
-        push!(args, :(s in $v && return getproperty(nt, $(QuoteNode(k)))))
-    end
-    push!(args, :(throw(ArgumentError("Objects of type `$(typeof(c))` do not have a property called `$s`"))))
-    return block
-end
-
 # Overload show method
 # Basic overloads
 Base.show(io::IO, mime::MIME"text/plain", x::WithNumbertype) = show(io, mime, DefaultShowOverload(x))
@@ -129,12 +149,14 @@ PlutoShowHelpers.shortname(x::AbstractSatcomCoordinate) = x |> typeof |> basetyp
 
 PlutoShowHelpers.repl_summary(p::AbstractSatcomCoordinate) = shortname(p) * " Coordinate"
 
-PlutoShowHelpers.show_namedtuple(c::LengthCartesian) = map(DisplayLength, normalized_properties(c))
+PlutoShowHelpers.show_namedtuple(c::AbstractSatcomCoordinate) = getproperties(c)
 
-function PlutoShowHelpers.show_namedtuple(c::AngleAngleDistance)
-    nt = getfields(c)
-    map(nt) do val
-        val isa Deg && return DualDisplayAngle(normalize_value(val))
-        val isa Met && return DisplayLength(normalize_value(val))
-    end
-end
+# PlutoShowHelpers.show_namedtuple(c::LengthCartesian) = map(DisplayLength, raw_properties(c))
+
+# function PlutoShowHelpers.show_namedtuple(c::AngleAngleDistance)
+#     nt = getfields(c)
+#     map(nt) do val
+#         val isa Deg && return DualDisplayAngle(normalize_value(val))
+#         val isa Met && return DisplayLength(normalize_value(val))
+#     end
+# end

--- a/src/functions/fallbacks.jl
+++ b/src/functions/fallbacks.jl
@@ -22,7 +22,7 @@ _position_properties(::CartesianPositionTrait, p::AbstractPosition) = map(to_met
 function _position_properties(::SphericalPositionTrait, p::AbstractPosition{T, 3}) where T
     a1, a2, r = raw_svector(p)
     nms = propertynames(p)
-    return NamedTuple{nms}(asdeg(a1), asdeg(a2), to_meters(r))
+    return NamedTuple{nms}((asdeg(a1), asdeg(a2), to_meters(r)))
 end
 
 function Base.getproperty(p::AbstractSatcomCoordinate, s::Symbol)
@@ -34,7 +34,7 @@ end
 # This function should take as input independent 
 function construct_inner_svector end
 
-function construct_inner_svector(::Type{<:AbstractPosition{T, N}}, args::Vararg{Real, N}) where {T <: AbstractFloat, N}
+function construct_inner_svector(::Type{<:AbstractPosition{T, N}}, args::Vararg{PS, N}) where {T <: AbstractFloat, N}
     return SVector{N, T}(args...)
 end
 

--- a/src/functions/fallbacks.jl
+++ b/src/functions/fallbacks.jl
@@ -53,6 +53,7 @@ end
 svector_size(::Type{<:StaticVector{N}}) where N = return N
 svector_size(::Type{<:AbstractSatcomCoordinate{<:Any, N}}) where N = return N
 
+## We use Val{NaN} to signal the constructor that it should fill the type with NaN values
 function (P::Type{<:Union{AbstractSatcomCoordinate, AbstractFieldValue}})(::Val{NaN})
     PT = enforce_numbertype(P)
     T = numbertype(PT)

--- a/src/functions/fieldvalues.jl
+++ b/src/functions/fieldvalues.jl
@@ -7,11 +7,11 @@ function raw_properties(fv::AbstractFieldValue{T, N, CRS}) where {T, N, CRS}
 end
 
 """
-    normalized_svector(fv::AbstractFieldValue)
+    raw_svector(fv::AbstractFieldValue)
 
 Return the `SVector` assumed to be contained in the `svector` field of `sv`, eventually stripped of its units if it originally storing `Quantity` elements.
 """
-function normalized_svector(fv::AbstractFieldValue)
+function raw_svector(fv::AbstractFieldValue)
     sv = getfield(fv, :svector)
     if eltype(sv) <: Quantity
         return map(ustrip, sv)

--- a/src/functions/fieldvalues.jl
+++ b/src/functions/fieldvalues.jl
@@ -1,21 +1,35 @@
-property_aliases(::Type{<:AbstractFieldValue{T, N, CRS}}) where {T, N, CRS} = property_aliases(CRS)
+# This is used to extract dimension directly from the unit type to construct a Quantity object
+dimension_from_units_type(::Type{<:Units{N, D}}) where {N, D} = D
 
-function raw_properties(fv::AbstractFieldValue{T, N, CRS}) where {T, N, CRS}
-    nms = property_names(CRS)
-    svector = getfield(fv, :svector)
-    return NamedTuple{nms}(Tuple(svector))
+svector_size(::Type{<:AbstractFieldValue{U, CRS}}) where {U, CRS} = svector_size(CRS)
+
+function _validate_crs(TP::Type{<:AbstractFieldValue{U, CRS}}) where {U, CRS}
+    CRS <: AbstractPosition || throw(ArgumentError("The `CRS` parameter of $TP must be a subtype of `AbstractPosition`"))
+    has_numbertype(CRS) && throw(ArgumentError("The `CRS` parameter of $TP must not contain the numbertype parameter."))
 end
 
-"""
-    raw_svector(fv::AbstractFieldValue)
-
-Return the `SVector` assumed to be contained in the `svector` field of `sv`, eventually stripped of its units if it originally storing `Quantity` elements.
-"""
-function raw_svector(fv::AbstractFieldValue)
-    sv = getfield(fv, :svector)
-    if eltype(sv) <: Quantity
-        return map(ustrip, sv)
-    else
-        return sv
-    end
+### Constructor
+function construct_inner_svector(TP::Type{<:AbstractFieldValue{U, CRS, T}}, args::Vararg{Number, N}) where {U, CRS, T, N}
+    _validate_crs(TP) # We validate the CRS parameter
+    NS = svector_size(TP)
+    N === NS || throw(ArgumentError("The provided `svector` has $N elements, but should have $(NS) elements as expected from the referenced `CRS` parameter ($CRS)."))
+    U === NoUnits && return SVector{N, T}(args...)
+    D = dimension_from_units_type(U)
+    Q = Quantity{T, D, U}
+    # We eventually add the unit and strip it to obtain the raw values
+    vals = map(ustrip ∘ Q, args)
+    return SVector{N, T}(vals...)
 end
+(P::Type{<:AbstractFieldValue})(args::Point{N, Number}) where {N} = P(args...)
+
+properties_names(::Type{<:AbstractFieldValue{U, CRS}}) where {U, CRS} = properties_names(CRS)
+
+function ConstructionBase.getproperties(fv::AbstractFieldValue{U, CRS}) where {U, CRS}
+    U === NoUnits && return raw_properties(fv)
+    D = dimension_from_units_type(U)
+    Q{T} = Quantity{T, D, U}
+    NamedTuple{properties_names(fv |> typeof)}(map(Q, raw_svector(fv)))
+end
+
+raw_svector(fv::AbstractFieldValue) = getfield(fv, :svector)
+raw_properties(fv::AbstractFieldValue) = NamedTuple{properties_names(fv |> typeof)}(raw_svector(fv) |> Tuple)

--- a/src/functions/geocentric.jl
+++ b/src/functions/geocentric.jl
@@ -1,4 +1,5 @@
 ##### Constructors #####
+position_trait(::Type{<:LLA}) = SphericalPositionTrait()
 
 ## ECI/ECEF
 # Handled by generic LengthCartesian constructor in fallbacks.jl
@@ -50,6 +51,6 @@ function Random.rand(rng::AbstractRNG, ::Random.SamplerType{E}) where E <: Union
     C = enforce_numbertype(E)
     T = numbertype(C)
     p = rand(rng, PointingVersor{T}) |> raw_svector
-    sv = p * (7e6 * ((1 + rand(rng))))
+    sv = p * (7e6 * ((1 + rand(rng)))) |> change_numbertype(T)
     constructor_without_checks(C, sv)
 end

--- a/src/functions/geocentric.jl
+++ b/src/functions/geocentric.jl
@@ -52,7 +52,7 @@ end
 function Random.rand(rng::AbstractRNG, ::Random.SamplerType{E}) where E <: Union{ECI, ECEF}
     C = enforce_numbertype(E)
     T = numbertype(C)
-    p = rand(rng, PointingVersor{T}) |> normalized_svector
+    p = rand(rng, PointingVersor{T}) |> raw_svector
     x, y, z = p * (7e6 * ((1 + rand(rng)) * u"m"))
     constructor_without_checks(C, x, y, z)
 end

--- a/src/functions/geocentric.jl
+++ b/src/functions/geocentric.jl
@@ -4,32 +4,27 @@
 # Handled by generic LengthCartesian constructor in fallbacks.jl
 
 ## LLA
-function LLA{T}(lat::ValidAngle, lon::ValidAngle, alt::ValidDistance) where T
-    any(isnan, (lat, lon, alt)) && return LLA{T}(Val{NaN}())
-    lat = to_degrees(lat)
-    lon = to_degrees(lon, RoundNearest)
+function construct_inner_svector(::Type{LLA{T}}, lat::ValidAngle, lon::ValidAngle, alt::ValidDistance) where T <: AbstractFloat
+    lat = to_degrees(lat) |> stripdeg
+    lon = to_degrees(lon, RoundNearest) |> stripdeg
     @assert -90° ≤ lat ≤ 90° "The input latitude must satisfy `lat ∈ [-90°, 90°]`"
-    alt = to_meters(alt)
-    constructor_without_checks(LLA{T}, lat, lon, alt)
+    alt = to_meters(alt) |> ustrip
+    return SVector{3, T}(lat, lon, alt)
 end
-function LLA(lat::ValidAngle, lon::ValidAngle, alt::ValidDistance)
-    T = default_numbertype(lat, lon, alt)
-    LLA{T}(lat, lon, alt)
-end
-(::Type{L})(lat::ValidAngle, lon::ValidAngle) where L <: LLA = L(lat, lon, 0)
+# Constructor without altitude
+(L::Type{<:LLA})(lat::ValidAngle, lon::ValidAngle) = L(lat, lon, 0)
 
 ##### Base.getproperty #####
 # LLA
-property_aliases(::Type{<:LLA}) = (
-    lat = LATITUDE_ALIASES,
-    lon = LONGITUDE_ALIASES,
-    alt = ALTITUDE_ALIASES
-)
+properties_names(::Type{<:LLA}) = (:lat, :lon, :alt)
 
 ##### Base.isapprox #####
-function Base.isapprox(x1::LLA, x2::LLA; angle_atol = deg2rad(1e-5), alt_atol = 1e-3, atol = nothing, kwargs...)
-    alt_atol = to_meters(alt_atol)
+function Base.isapprox(x1::LLA, x2::LLA; angle_atol = 1e-5°, alt_atol = 1e-3, atol = nothing, kwargs...)
+    alt_atol = to_meters(alt_atol) |> ustrip
+    angle_atol = to_degrees(angle_atol) |> stripdeg
 	@assert atol isa Nothing "You can't provide an absolute tolerance directly for comparing `LLA` objects, please use the independent kwargs `angle_atol` [radians] for the longitude and latitude atol and `alt_atol` [m] for the altitude one"
+    x1 = raw_properties(x1)
+    x2 = raw_properties(x2)
 	# Altitude, we default to an absolute tolerance of 1mm for isapprox
 	isapprox(x1.alt,x2.alt; atol = alt_atol, kwargs...) || return false
 	# Angles, we default to a default tolerance of 1e-5 degrees for isapprox
@@ -43,16 +38,18 @@ end
 
 ##### Random.rand #####
 function Random.rand(rng::AbstractRNG, ::Random.SamplerType{L}) where L <: LLA
-    lat = rand(rng) * 180° - 90°
-    lon = rand(rng) * 360° - 180°
-    alt = 0.0 * u"m"
-    constructor_without_checks(enforce_numbertype(L), lat, lon, alt)
+    LT = enforce_numbertype(L)
+    T = numbertype(LT)
+    lat = rand(rng) * π - π/2
+    lon = rand(rng) * 2π - π
+    alt = 0.0
+    constructor_without_checks(LT, SVector{3, T}(lat, lon, alt))
 end
 
 function Random.rand(rng::AbstractRNG, ::Random.SamplerType{E}) where E <: Union{ECI, ECEF}
     C = enforce_numbertype(E)
     T = numbertype(C)
     p = rand(rng, PointingVersor{T}) |> raw_svector
-    x, y, z = p * (7e6 * ((1 + rand(rng)) * u"m"))
-    constructor_without_checks(C, x, y, z)
+    sv = p * (7e6 * ((1 + rand(rng))))
+    constructor_without_checks(C, sv)
 end

--- a/src/functions/local.jl
+++ b/src/functions/local.jl
@@ -107,8 +107,10 @@ has_pointingtype(::Type{<:GeneralizedSpherical{P}}) where {P} = return true
 # Returns the pointing type of a GeneralizedSpherical subtype, if it's unique or throw an error otherwise
 pointing_type(::Type{GeneralizedSpherical}) = throw(ArgumentError("No pointing type can be uniquely inferred from GeneralizedSpherical"))
 pointing_type(::Type{<:GeneralizedSpherical{P}}) where {P} = P
+pointing_type(g::GeneralizedSpherical) = pointing_type(typeof(g))
 
 # #### Custom show methods ####
 
 PlutoShowHelpers.shortname(::Spherical) = "Spherical"
 PlutoShowHelpers.shortname(::AzElDistance) = "AzElDistance"
+PlutoShowHelpers.shortname(::GeneralizedSpherical{P, T}) where {P, T} = "GeneralizedSpherical{$(shortname(P{T}))}"

--- a/src/functions/pointing.jl
+++ b/src/functions/pointing.jl
@@ -289,8 +289,8 @@ function Random.rand(rng::AbstractRNG, ::Random.SamplerType{AE}) where AE <: Uni
 end
 
 ##### Utilities #####
-svector_size(::Type{<:AbstractPointing}) = 2
-svector_size(::Type{<:PointingVersor}) = 3
+svector_size(::Type{<:AbstractPointing}) = return 2
+svector_size(::Type{<:PointingVersor}) = return 3
 
 ###### Custom show overloads ######
 PlutoShowHelpers.repl_summary(p::PointingVersor) = "PointingVersor"

--- a/src/functions/pointing.jl
+++ b/src/functions/pointing.jl
@@ -289,6 +289,8 @@ function Random.rand(rng::AbstractRNG, ::Random.SamplerType{AE}) where AE <: Uni
 end
 
 ##### Utilities #####
+svector_size(::Type{<:AbstractPointing}) = 2
+svector_size(::Type{<:PointingVersor}) = 3
 
 ###### Custom show overloads ######
 PlutoShowHelpers.repl_summary(p::PointingVersor) = "PointingVersor"

--- a/src/functions/pointing.jl
+++ b/src/functions/pointing.jl
@@ -181,7 +181,7 @@ end
 - p̂ ⋅ û = w
 =#
 function _convert_different(::Type{E}, p::PointingVersor) where E <: AzEl
-    (;u,v,w) = raw_properties(p)
+    u,v,w = raw_svector(p)
     az = atan(u, v) # Already in the [-180°, 180°] range
     el = asin(w) # Already in the [-90°, 90°] range
     ET = enforce_numbertype(E, p)
@@ -202,7 +202,7 @@ end
 
 # ElOverAz <-> PointingVersor
 function _convert_different(::Type{E}, p::PointingVersor) where E <: ElOverAz
-    (;u,v,w) = raw_properties(p)
+    u,v,w = raw_svector(p)
     az = atan(-u,w) # Already in the [-180°, 180°] range
     el = asin(v) # Already in the [-90°, 90°] range
     ET = enforce_numbertype(E, p)
@@ -223,7 +223,7 @@ end
 
 # AzOverEl <-> PointingVersor
 function _convert_different(::Type{A}, p::PointingVersor) where A <: AzOverEl
-    (;u,v,w) = raw_properties(p)
+    u,v,w = raw_svector(p)
     el = atan(v/w) # Already returns a value in the range [-90°, 90°]
     az = asin(-u) # This only returns the value in the [-90°, 90°] range
     # Make the angle compatible with our ranges of azimuth and elevation

--- a/src/functions/pointing_offsets.jl
+++ b/src/functions/pointing_offsets.jl
@@ -3,7 +3,7 @@ function construct_inner_svector(PO::Type{PointingOffset{P, T}}, x, y) where {P 
     _validate_type(PO)
     sv = SVector{2, T}(x, y)
     if P <: AngularPointing
-        sv = map(ustrip ∘ to_degrees, sv)
+        sv = map(stripdeg ∘ to_degrees, sv)
     end
     return sv
 end

--- a/src/functions/pointing_offsets.jl
+++ b/src/functions/pointing_offsets.jl
@@ -62,8 +62,8 @@ offset.theta ≈ Δθ
 See also: [`add_angular_offset`](@ref), [`get_angular_offset`](@ref)
 """
 function get_angular_distance(p₁::AbstractPointing, p₂::AbstractPointing)
-	p₁_xyz = convert(PointingVersor, p₁) |> normalized_svector
-	p₂_xyz = convert(PointingVersor, p₂) |> normalized_svector
+	p₁_xyz = convert(PointingVersor, p₁) |> raw_svector
+	p₂_xyz = convert(PointingVersor, p₂) |> raw_svector
 	return acos(min(p₁_xyz'p₂_xyz, 1)) |> asdeg
 end
 
@@ -144,7 +144,7 @@ See also: [`add_angular_offset`](@ref)
 """
 function get_angular_offset(p₁::AbstractPointing, p₂::AbstractPointing)
 	R = angle_offset_rotation(convert(ThetaPhi, p₁)) # We take p₁ as reference
-	p₂_xyz = convert(PointingVersor, p₂) |> normalized_svector # We create the 3D vector corresponding to p₂
+	p₂_xyz = convert(PointingVersor, p₂) |> raw_svector # We create the 3D vector corresponding to p₂
 	# Check the comments in `angle_offset_rotation` and the link therein to understand this line
 	x, y, z = R' * p₂_xyz
     out = constructor_without_checks(enforce_numbertype(PointingVersor, x), x, y, z)
@@ -198,7 +198,7 @@ See also: [`get_angular_offset`](@ref), [`get_angular_distance`](@ref), [`ThetaP
 function add_angular_offset(::Type{O}, p₀::P, offset_angles::ThetaPhi) where {O <: AbstractPointing, P <: AbstractPointing}
 	θφ_in = convert(ThetaPhi, p₀)
 	R = angle_offset_rotation(θφ_in)
-	perturbation = convert(PointingVersor, offset_angles) |> normalized_svector
+	perturbation = convert(PointingVersor, offset_angles) |> raw_svector
 	# Check the comments in `angle_offset_rotation` and the link therein to understand this line
 	x,y,z = R * perturbation
     out_direction = constructor_without_checks(enforce_numbertype(PointingVersor, x), x, y, z)
@@ -215,4 +215,4 @@ PlutoShowHelpers.repl_summary(p::AbstractPointingOffset) = shortname(p.inner) * 
 
 PlutoShowHelpers.show_namedtuple(p::UVOffset) = show_namedtuple(p.inner)
 
-PlutoShowHelpers.show_namedtuple(p::ThetaPhiOffset) = map(DualDisplayAngle, normalized_properties(p.inner))
+PlutoShowHelpers.show_namedtuple(p::ThetaPhiOffset) = map(DualDisplayAngle, raw_properties(p.inner))

--- a/src/functions/pointing_offsets.jl
+++ b/src/functions/pointing_offsets.jl
@@ -1,41 +1,40 @@
 ##### Constructors #####
-(::Type{UO})(::Val{NaN}) where UO <: UVOffset = constructor_without_checks(enforce_numbertype(UO), NaN, NaN)
-function UVOffset{T}(u, v) where {T <: AbstractFloat}
-    any(isnan, (u, v)) && return UVOffset{T}(Val{NaN}())
-    constructor_without_checks(UVOffset{T}, u, v)
-end
-function UVOffset(uv::Vararg{Real, 2})
-    T = default_numbertype(uv...)
-    return UVOffset{T}(uv...)
-end
-# ThetaPhiOffset
-(::Type{TPO})(::Val{NaN}) where TPO <: ThetaPhiOffset = constructor_without_checks(enforce_numbertype(TPO), NaN * u"°", NaN * u"°")
-function (::Type{TPO})(args...) where TPO <: ThetaPhiOffset
-    tp = ThetaPhi(args...)
-    TP = enforce_numbertype(TPO, tp)
-    return constructor_without_checks(TP, tp)
+function construct_inner_svector(PO::Type{PointingOffset{P, T}}, x, y) where {P <: Union{UV, AngularPointing}, T}
+    _validate_type(PO)
+    sv = SVector{2, T}(x, y)
+    if P <: AngularPointing
+        sv = map(ustrip ∘ to_degrees, sv)
+    end
+    return sv
 end
 
-##### Base.getproperty #####
-property_aliases(::Type{<:UVOffset}) = property_aliases(UV)
-property_aliases(::Type{<:ThetaPhiOffset}) = property_aliases(ThetaPhi)
+_validate_type(::Type{<:PointingOffset{P}}) where P = P === basetype(P) || throw(ArgumentError("When defining `PointingOffset{P, T}` types, `P` can only be a subtype of `UV` or `AngularPointing` without its numbertype parameter expressed. You should define `P` as `$(basetype(P))` instead of the provided `$(P)`"))
 
-##### raw_properties #####
-raw_properties(po::AbstractPointingOffset) = raw_properties(getfield(po, :inner))
+_as_pointing(po::PointingOffset{P, T}) where {P, T} = constructor_without_checks(P{T}, raw_svector(po))
+_from_pointing(uv::UV) = constructor_without_checks(PointingOffset{UV, numbertype(uv)}, raw_svector(uv))
+_from_pointing(p::AngularPointing) = constructor_without_checks(PointingOffset{basetype(p), numbertype(p)}, raw_svector(p))
+
+##### properties_names #####
+properties_names(::Type{<:PointingOffset{P}}) where P = properties_names(P)
+
+##### getproperties ####
+ConstructionBase.getproperties(p::PointingOffset{<:AngularPointing}) = map(asdeg, raw_properties(p))
 
 ##### Basic Operations #####
 function Base.:(-)(uv1::UV, uv2::UV) 
     T = promote_type(numbertype(uv1), numbertype(uv2))
-    return constructor_without_checks(UVOffset{T}, uv1.u - uv2.u, uv1.v - uv2.v)
+    sv = SVector{2, T}(uv1.u - uv2.u, uv1.v - uv2.v)
+    return constructor_without_checks(PointingOffset{UV, T}, sv)
 end
 Base.:(+)(uv::UV, δuv::UVOffset) = UV(uv.u + δuv.u, uv.v + δuv.v)
 
 ##### Random.rand #####
-function Random.rand(rng::AbstractRNG, ::SamplerType{P}) where P <: Union{UVOffset, ThetaPhiOffset}
-    PT = enforce_numbertype(P)  
-    T = numbertype(PT)
-    ST = P <: UVOffset ? UV{T} : ThetaPhi{T}
-    return constructor_without_checks(PT, rand(rng, ST))
+function Random.rand(rng::AbstractRNG, ::SamplerType{PO}) where {P, PO <: PointingOffset{P}}
+    _validate_type(PO)
+    POT = enforce_numbertype(PO)
+    T = numbertype(POT)
+    sv = rand(rng, P{T}) |> raw_svector
+    return constructor_without_checks(POT, sv)
 end
 
 #### Utilities ####
@@ -146,14 +145,14 @@ function get_angular_offset(p₁::AbstractPointing, p₂::AbstractPointing)
 	R = angle_offset_rotation(convert(ThetaPhi, p₁)) # We take p₁ as reference
 	p₂_xyz = convert(PointingVersor, p₂) |> raw_svector # We create the 3D vector corresponding to p₂
 	# Check the comments in `angle_offset_rotation` and the link therein to understand this line
-	x, y, z = R' * p₂_xyz
-    out = constructor_without_checks(enforce_numbertype(PointingVersor, x), x, y, z)
+    T = promote_type(numbertype(p₁), numbertype(p₂))
+	sv = R' * p₂_xyz
+    out = constructor_without_checks(PointingVersor{T}, sv)
 	# We transform from local cartesian coordinates into ThetaPhi, and then we
 	# convert into ThetaPhiOffset to emphasize that this is not a pointing
 	# direction.
 	tp = convert(ThetaPhi, out)
-    P = enforce_numbertype(ThetaPhiOffset, tp)
-    return constructor_without_checks(P, tp)
+    return _from_pointing(tp)
 end
 
 """
@@ -200,19 +199,19 @@ function add_angular_offset(::Type{O}, p₀::P, offset_angles::ThetaPhi) where {
 	R = angle_offset_rotation(θφ_in)
 	perturbation = convert(PointingVersor, offset_angles) |> raw_svector
 	# Check the comments in `angle_offset_rotation` and the link therein to understand this line
-	x,y,z = R * perturbation
-    out_direction = constructor_without_checks(enforce_numbertype(PointingVersor, x), x, y, z)
+    T = promote_type(numbertype(p₀), numbertype(offset_angles))
+	sv = R * perturbation
+    out_direction = constructor_without_checks(PointingVersor{T}, sv)
     O <: UV && @assert out_direction.z >= 0 "The resulting point has a θ > 90°, so it is located behind the viewer.
 Call the function with an explicit non-UV output type to allow target points behind the viewer."
     convert(O, out_direction)
 end
 add_angular_offset(O::Type{<:AbstractPointing}, p₀::AbstractPointing, θ::ValidAngle, φ::ValidAngle = 0.0) = add_angular_offset(O, p₀, ThetaPhi(θ, φ))
-add_angular_offset(O::Type{<:AbstractPointing}, p₀::AbstractPointing, tpo::ThetaPhiOffset) = add_angular_offset(O, p₀, tpo.inner)
+add_angular_offset(O::Type{<:AbstractPointing}, p₀::AbstractPointing, tpo::ThetaPhiOffset) = add_angular_offset(O, p₀, _as_pointing(tpo))
 add_angular_offset(p₀::AbstractPointing, args...) = add_angular_offset(typeof(p₀), p₀, args...)
 
 ##### custom show overloads #####
-PlutoShowHelpers.repl_summary(p::AbstractPointingOffset) = shortname(p.inner) * " Pointing Offset"
+PlutoShowHelpers.repl_summary(p::PointingOffset) = shortname(_as_pointing(p)) * " Pointing Offset"
+PlutoShowHelpers.shortname(p::PointingOffset{P, T}) where {P, T} = shortname(P{T})*"Offset"
 
-PlutoShowHelpers.show_namedtuple(p::UVOffset) = show_namedtuple(p.inner)
-
-PlutoShowHelpers.show_namedtuple(p::ThetaPhiOffset) = map(DualDisplayAngle, raw_properties(p.inner))
+PlutoShowHelpers.show_namedtuple(p::PointingOffset) = show_namedtuple(_as_pointing(p))

--- a/src/functions/topocentric.jl
+++ b/src/functions/topocentric.jl
@@ -64,7 +64,7 @@ end
 function _convert_different(::Type{A}, src::S) where {A <: AER, S <: Union{ENU, NED}}
     C = enforce_numbertype(A, src)
     enu = convert(ENU, src)
-    sv = normalized_svector(enu)
+    sv = raw_svector(enu)
     r = norm(sv) * u"m"
     (;az, el) = convert(AzEl, PointingVersor(sv...))
     constructor_without_checks(C, az, el, r)
@@ -75,7 +75,7 @@ function _convert_different(::Type{S}, src::A) where {S <: Union{ENU, NED}, A <:
     (; az, el, r) = src
     ae = constructor_without_checks(AzEl{T}, az, el)
     p = convert(PointingVersor, ae)
-    (;x, y, z) = normalized_svector(p) .* r
+    (;x, y, z) = raw_svector(p) .* r
     enu = constructor_without_checks(ENU{T}, x, y, z)
     convert(S, enu)
 end
@@ -86,4 +86,4 @@ function Base.isapprox(c1::TopocentricPosition, c2::TopocentricPosition; kwargs.
     e2 = convert(ENU, c2)
     isapprox(e1, e2; kwargs...)
 end
-Base.isapprox(c1::ENU, c2::ENU; kwargs...) = isapprox(normalized_svector(c1), normalized_svector(c2); kwargs...)
+Base.isapprox(c1::ENU, c2::ENU; kwargs...) = isapprox(raw_svector(c1), raw_svector(c2); kwargs...)

--- a/src/functions/topocentric.jl
+++ b/src/functions/topocentric.jl
@@ -1,87 +1,82 @@
+position_trait(::Type{<:AER}) = SphericalPositionTrait()
+
 ##### Constructors #####
 
 # ENU/NED
 # Handled by generic LengthCartesian constructor in fallbacks.jl
 
 # AER
-function AER{T}(az::ValidAngle, el::ValidAngle, r::ValidDistance) where T
-    any(isnan, (az, el, r)) && return AER{T}(Val{NaN}())
+function construct_inner_svector(::Type{AER{T}}, az::ValidAngle, el::ValidAngle, r::ValidDistance) where T
     az = to_degrees(az, RoundNearest)
     el = to_degrees(el, RoundNearest)
     az, el = wrap_spherical_angles_normalized(az, el, AER)
-    r = to_meters(r)
-    constructor_without_checks(AER{T}, az, el, r)
-end
-function AER(az::ValidAngle, el::ValidAngle, r::ValidDistance)
-    T = default_numbertype(az, el, r)
-    AER{T}(az, el, r)
+    az = stripdeg(az)
+    el = stripdeg(el)
+    r = to_meters(r) |> ustrip
+    SVector{3, T}(az, el, r)
 end
 
 ##### Pointing Inversion #####
-Base.:(-)(aer::AER) = constructor_without_checks(typeof(aer), aer.az - copysign(180°, aer.az), -aer.el, aer.r)
+function Base.:(-)(aer::AER) 
+    AE = typeof(aer)
+    T = numbertype(AE)
+    az, el, r = raw_svector(aer)
+    az = az - copysign(π, az)
+    el = -el
+    constructor_without_checks(AE, SVector{3, T}(az, el, r))
+end
 
 ##### Base.getproperty #####
-## ENU
-property_aliases(::Type{<:ENU}) = (
-    x = (:x, :east),
-    y = (:y, :north),
-    z = (:z, :up)
-)
-
-## NED
-property_aliases(::Type{<:NED}) = (
-    x = (:x, :north),
-    y = (:y, :east),
-    z = (:z, :down)
-)
+## ENU/NED covered by position fallback
 
 ## AER
-property_aliases(::Type{<:AER}) = (
-    az = AZIMUTH_ALIASES,
-    el = ELEVATION_ALIASES,
-    r = DISTANCE_ALIASES
-)
+properties_names(::Type{<:AER}) = (:az, :el, :r)
 
 ##### Random.rand #####
 function Random.rand(rng::AbstractRNG, ::Random.SamplerType{A}) where A <: AER
-    az = rand(rng) * 360° - 180°
-    el = rand(rng) * 180° - 90°
-    r = 1e3 * ((1 + rand(rng)) * u"m")
-    constructor_without_checks(enforce_numbertype(A), az, el, r)
+    AE = enforce_numbertype(A)
+    T = numbertype(AE)
+    az = rand(rng) * π - π/2
+    el = rand(rng) * π/2 - π/4
+    r = 1e3 * (1 + rand(rng))
+    constructor_without_checks(AE, SVector{3, T}(az, el, r))
 end
 # ENU/NED
 # Handled by generic LengthCartesian function in fallbacks.jl
 
 ##### convert #####
 ## ENU <-> NED
-function _convert_different(::Type{T}, src::S) where {T <: Union{ENU, NED}, S <: Union{ENU, NED}}
-    C = enforce_numbertype(T, src)
-    (;x, y, z) = src
-    constructor_without_checks(C, y, x, -z)
+function _convert_different(CRSₒ::Type{<:Union{ENU, NED}}, src::Union{ENU, NED})
+    C = enforce_numbertype(CRSₒ, src)
+    T = numbertype(C)
+    x, y, z = raw_svector(src)
+    constructor_without_checks(C, SVector{3, T}(y, x, -z))
 end
 
 ## ENU/NED <-> AER
-function _convert_different(::Type{A}, src::S) where {A <: AER, S <: Union{ENU, NED}}
+function _convert_different(A::Type{<:AER}, src::Union{ENU, NED})
     C = enforce_numbertype(A, src)
+    T = numbertype(C)
     enu = convert(ENU, src)
     sv = raw_svector(enu)
-    r = norm(sv) * u"m"
-    (;az, el) = convert(AzEl, PointingVersor(sv...))
-    constructor_without_checks(C, az, el, r)
+    r = norm(sv)
+    p = constructor_without_checks(PointingVersor{T}, sv ./ r)
+    (;az, el) = convert(AzEl, p) |> raw_properties
+    constructor_without_checks(C, SVector{3, T}(az, el, r))
 end
-function _convert_different(::Type{S}, src::A) where {S <: Union{ENU, NED}, A <: AER}
+function _convert_different(S::Type{<:Union{ENU, NED}}, src::AER)
     C = enforce_numbertype(S, src)
     T = numbertype(C)
-    (; az, el, r) = src
-    ae = constructor_without_checks(AzEl{T}, az, el)
+    (; az, el, r) = raw_properties(src)
+    ae = constructor_without_checks(AzEl{T}, SVector{2, T}(az, el))
     p = convert(PointingVersor, ae)
-    (;x, y, z) = raw_svector(p) .* r
-    enu = constructor_without_checks(ENU{T}, x, y, z)
+    sv = raw_svector(p) * r
+    enu = constructor_without_checks(ENU{T}, sv)
     convert(S, enu)
 end
 
 ##### Base.isapprox #####
-function Base.isapprox(c1::TopocentricPosition, c2::TopocentricPosition; kwargs...)
+function Base.isapprox(c1::AbstractTopocentricPosition, c2::AbstractTopocentricPosition; kwargs...)
     e1 = convert(ENU, c1)
     e2 = convert(ENU, c2)
     isapprox(e1, e2; kwargs...)

--- a/src/functions/traits.jl
+++ b/src/functions/traits.jl
@@ -1,0 +1,2 @@
+position_trait(::Type{<:AbstractPosition}) = CartesianPositionTrait()
+position_trait(coords::AbstractPosition) = position_trait(typeof(coords))

--- a/src/functions/transforms.jl
+++ b/src/functions/transforms.jl
@@ -4,7 +4,10 @@
 CRSRotation(R::StaticMatrix{3, 3}) = CRSRotation(nearest_rotation(R))
 
 # Basic transform
-BasicCRSTransform(rotation::StaticMatrix{3, 3}, origin::CartesianPosition) = BasicCRSTransform(CRSRotation(rotation), origin)
+function BasicCRSTransform(rotation::StaticMatrix{3, 3}, origin::AbstractPosition) 
+    position_trait(origin) isa CartesianPositionTrait || throw(ArgumentError("`origin` must be a position in Cartesian coordinates"))
+    BasicCRSTransform(CRSRotation(rotation), origin)
+end
 
 
 ##### Our Interface #####

--- a/src/functions/transforms.jl
+++ b/src/functions/transforms.jl
@@ -46,7 +46,7 @@ TransformsBase.parameters(t::AbstractCRSTransform) = getfields(t)
 
 # Fallback apply, actual methods should be defined taking StaticVector as reference input if not for special cases
 function TransformsBase.apply(t::AbstractCRSTransform, coords::LocalCartesian) 
-    new_coords, _ = apply(t, normalized_svector(coords))
+    new_coords, _ = apply(t, raw_svector(coords))
     return LocalCartesian(new_coords), nothing
 end
 
@@ -64,12 +64,12 @@ TransformsBase.apply(t::AbstractCRSRotation, coords::StaticVector) =
 # Affine transform
 function TransformsBase.apply(t::AbstractAffineCRSTransform, coords::StaticVector)
     rotated, _ = apply(rotation(t), coords)
-    new_coords = rotated + normalized_svector(origin(t))
+    new_coords = rotated + raw_svector(origin(t))
     return new_coords, nothing
 end
 
 function TransformsBase.apply(t::InverseTransform{<:Any, <:AbstractAffineCRSTransform}, coords::StaticVector)
-    shifted = coords - normalized_svector(origin(t))
+    shifted = coords - raw_svector(origin(t))
     rotated, _ = apply(rotation(t), shifted)
     return rotated, nothing
 end

--- a/src/types/abstract_types.jl
+++ b/src/types/abstract_types.jl
@@ -70,19 +70,20 @@ Abstract type representing an affine transform between two CRSs with numbertype 
 abstract type AbstractAffineCRSTransform{T} <: AbstractCRSTransform{T} end
 
 """
-    AbstractFieldValue{T, N, CRS <: AbstractPosition{T, N}, F}
+    AbstractFieldValue{U, CRS, T}
 
-Abstract type representing the value of a physical field expressed in a specific `CRS` in `N` dimensions with numbertype `T`.
+Abstract type representing the value of a physical field expressed in a specific coordinate reference system `CRS`, and whose components have an associated unit `U` and a numbertype `T`.
 
 A method of `property_aliases` is defined for this abstract type that simply returns `property_aliases(CRS)`.
 
-Default concrete implementations of this subtype are expected to have a single inner field `svector` which is a `SVector{N, F}` to exploit the `raw_properties` method defined on this abstract type.
+Default concrete implementations of this subtype are expected to have a single inner field `svector` which is a `SVector{N, T}` (`N` being the number of dimensions of the referenced `CRS`) to exploit the `raw_properties` method defined on this abstract type.
 
 An example concrete type representing velocity in a 3D CRS can be implemented as follows (assuming to have `Quantity`, `@u_str` and `dimension` imported from `Unitful`):
 
 ```julia
-struct VelocityFieldValue{T, CRS <: CartesianPosition{T, 3}} <: AbstractFieldValue{T, 3, CRS, Quantity{T, dimension(u"m/s"), typeof(u"m/s")}}
-    svector::SVector{3, Quantity{T, dimension(u"m/s"), typeof(u"m/s")}}
+const U = typeof(u"m/s")
+struct VelocityFieldValue{CRS <: AbstractPosition{<:Any, 3}, T} <: AbstractFieldValue{U, CRS, T}
+    svector::SVector{3, T}
 end
 ```
 
@@ -93,4 +94,4 @@ end
 - `raw_svector(::AbstractFieldValue)`: Assumes that the concrete subtype has a field called `svector` and simply returns it, eventually stripping the units from the elements if they are of type `Quantity`.
 - `Base.getproperty(::AbstractFieldValue, ::Symbol)`: Based on the same `@generated` function used for objects of type `AbstractSatcomCoordinate` and requiring `property_aliases` and `raw_properties` to be defined for the concrete subtype.
 """
-abstract type AbstractFieldValue{CRS, F} end
+abstract type AbstractFieldValue{U <: Units, CRS, T} end

--- a/src/types/abstract_types.jl
+++ b/src/types/abstract_types.jl
@@ -25,6 +25,20 @@ Abstract type representing a position in a local coordinate system.
 abstract type AbstractLocalPosition{T, N} <: AbstractPosition{T, N} end
 
 """
+    AbstractTopocentricPosition{T} <: AbstractPosition{T, 3}
+
+Abstract type representing a position in a topocentric coordinate system.
+"""
+abstract type AbstractTopocentricPosition{T} <: AbstractPosition{T, 3} end
+
+"""
+    AbstractGeocentricPosition{T} <: AbstractPosition{T, 3}
+
+Abstract type representing a position in a geocentric coordinate system.
+"""
+abstract type AbstractGeocentricPosition{T} <: AbstractPosition{T, 3} end
+
+"""
     AngularPointing{T}
 
 Abstract type representing a pointing direction identified by two angles in

--- a/src/types/abstract_types.jl
+++ b/src/types/abstract_types.jl
@@ -11,34 +11,18 @@ abstract type AbstractSatcomCoordinate{T, N} end
 abstract type AbstractPosition{T, N} <: AbstractSatcomCoordinate{T, N} end
 
 """
-    AngleAngleDistance{T} <: AbstractSatcomCoordinate{T, 3}
-
-Abstract type representing a position in 3 dimensions, identified by two angles and a distance.
-"""
-abstract type AngleAngleDistance{T} <: AbstractPosition{T, 3} end
-
-"""
-    CartesianPosition{T, N} <: AbstractSatcomCoordinate{T, N}
-
-Abstract type representing a coordinate in `N` dimensions which is backed by
-fields all of type `T`. 
-Concrete subtypes of this are subtypes of `FieldVector`
-"""
-abstract type CartesianPosition{T, N} <: AbstractPosition{T, N} end
-
-"""
-    LengthCartesian{T, N} <: CartesianPosition{T, N}
-
-Abstract type representing a coordinate in `N` dimensions which is backed by fields all of type `Met{T}`. 
-"""
-abstract type LengthCartesian{T, N} <: CartesianPosition{T, N} end
-
-"""
     AbstractPointing{T} <: AbstractSatcomCoordinate{T, 3}
 
 Abstract type representing a pointing direction in 3 dimensions which is backed by fields with shared [`numbertype`](@ref) `T`.
 """
 abstract type AbstractPointing{T} <: AbstractSatcomCoordinate{T, 3} end
+
+"""
+    AbstractLocalPosition{T} <: AbstractPosition{T, 3}
+
+Abstract type representing a position in a local coordinate system.
+"""
+abstract type AbstractLocalPosition{T, N} <: AbstractPosition{T, N} end
 
 """
     AngularPointing{T}
@@ -92,7 +76,7 @@ end
 `SatcomCoordinates.jl` currently does not implement concrete subtypes of `AbstractFieldValue`, but only defines the following methods: 
 - `raw_properties(::AbstractFieldValue{T, N, CRS, F})`: Assumes that the concrete subtype has a field called `svector` which is an `SVector{N, F}`
 - `property_aliases(::Type{<:AbstractFieldValue{T, N, CRS}})`: Simply returns `property_aliases(CRS)`
-- `normalized_svector(::AbstractFieldValue)`: Assumes that the concrete subtype has a field called `svector` and simply returns it, eventually stripping the units from the elements if they are of type `Quantity`.
+- `raw_svector(::AbstractFieldValue)`: Assumes that the concrete subtype has a field called `svector` and simply returns it, eventually stripping the units from the elements if they are of type `Quantity`.
 - `Base.getproperty(::AbstractFieldValue, ::Symbol)`: Based on the same `@generated` function used for objects of type `AbstractSatcomCoordinate` and requiring `property_aliases` and `raw_properties` to be defined for the concrete subtype.
 """
-abstract type AbstractFieldValue{T, N, CRS <: AbstractPosition{T, N}, F} end
+abstract type AbstractFieldValue{CRS, F} end

--- a/src/types/geocentric.jl
+++ b/src/types/geocentric.jl
@@ -1,8 +1,8 @@
 """
-    struct ECEF{T} <: LengthCartesian{T, 3}
+    struct ECEF{T} <: AbstractGeocentricPosition{T}
 Represents a position in the Earth-Centered, Earth-Fixed (ECEF) coordinate system (or generically for other planets, Ellipsoid-Centered, Ellipsoid-Fixed).
 
-# Fields
+# Properties
 - `x::Met{T}`: X-coordinate in meters
 - `y::Met{T}`: Y-coordinate in meters
 - `z::Met{T}`: Z-coordinate in meters
@@ -20,19 +20,17 @@ All subtypes of `P <: AbstractSatcomCoordinate` can also be constructed using a 
 
 See also: [`ECI`](@ref), [`LLA`](@ref).
 """
-struct ECEF{T} <: LengthCartesian{T, 3}
-    x::Met{T}
-    y::Met{T}
-    z::Met{T}
+struct ECEF{T} <: AbstractGeocentricPosition{T}
+    svector::SVector{3, T}
 
-    BasicTypes.constructor_without_checks(::Type{ECEF{T}}, x, y, z) where T = new{T}(x, y, z)
+    BasicTypes.constructor_without_checks(::Type{ECEF{T}}, sv::SVector{3, T}) where T = new{T}(sv)
 end
 
 """
-    struct ECI{T} <: LengthCartesian{T, 3}
+    struct ECI{T} <: AbstractGeocentricPosition{T}
 Represents a position in the Earth-Centered, Inertial (ECI) coordinate system (or generically for other planets, Ellipsoid-Centered, Inertial).
 
-# Fields
+# Properties
 - `x::Met{T}`: X-coordinate in meters
 - `y::Met{T}`: Y-coordinate in meters
 - `z::Met{T}`: Z-coordinate in meters
@@ -50,27 +48,20 @@ All subtypes of `P <: AbstractSatcomCoordinate` can also be constructed using a 
 
 See also: [`ECEF`](@ref), [`LLA`](@ref).
 """
-struct ECI{T} <: LengthCartesian{T, 3}
-    x::Met{T}
-    y::Met{T}
-    z::Met{T}
+struct ECI{T} <: AbstractGeocentricPosition{T}
+    svector::SVector{3, T}
 
-    BasicTypes.constructor_without_checks(::Type{ECI{T}}, x, y, z) where T = new{T}(x, y, z)
+    BasicTypes.constructor_without_checks(::Type{ECI{T}}, sv::SVector{3, T}) where T = new{T}(sv)
 end
 
 """
-    struct LLA{T} <: AngleAngleDistance{T}
+    struct LLA{T} <: AbstractGeocentricPosition{T}
 Identify a point on or above earth using geodetic coordinates
 
-# Fields
+# Properties
 - `lat::Deg{T}`: Latitude of the point in degrees [-90°, 90°]
 - `lon::Deg{T}`: Longitude of the point in degrees [-180°, 180°]
 - `alt::Met{T}`: Altitude of the point above the reference ellipsoid
-
-The fields of `LLA` objects can also be accessed via `getproperty` using the follwing alternative aliases:
-- `latitude` for `lat`
-- `longitude` for `lon`
-- `altitude`, `h` or `height` for `alt`
 
 # Basic Constructors
     LLA(lat::ValidAngle,lon::ValidAngle,alt::ValidDistance)
@@ -89,10 +80,8 @@ All subtypes of `P <: AbstractSatcomCoordinate` can also be constructed using a 
 
 See also: [`ECEF`](@ref), [`ECI`](@ref).
 """
-struct LLA{T} <: AngleAngleDistance{T}
-    lat::Deg{T}
-    lon::Deg{T}
-    alt::Met{T}
+struct LLA{T} <: AbstractGeocentricPosition{T}
+    svector::SVector{3, T}
 
-    BasicTypes.constructor_without_checks(::Type{LLA{T}}, lat, lon, alt) where T = new{T}(lat, lon, alt)
+    BasicTypes.constructor_without_checks(::Type{LLA{T}}, sv::SVector{3, T}) where T = new{T}(sv)
 end

--- a/src/types/local.jl
+++ b/src/types/local.jl
@@ -48,8 +48,8 @@ If of the provided argument is `NaN`, the returned `PointingAndDistance` object 
 
 See also: [`Spherical`](@ref), [`AzElDistance`](@ref), [`LocalCartesian`](@ref).
 """
-struct GeneralizedSpherical{T, P <: AngularPointing} <: AbstractLocalPosition{T, 3}
+struct GeneralizedSpherical{P <: AngularPointing, T} <: AbstractLocalPosition{T, 3}
     svector::SVector{3, T}
 
-    BasicTypes.constructor_without_checks(::Type{GeneralizedSpherical{T, P}}, svector::SVector{3, T}) where {T, P} = new{T, P}(svector)
+    BasicTypes.constructor_without_checks(::Type{GeneralizedSpherical{P, T}}, svector::SVector{3, T}) where {T, P} = new{P, T}(svector)
 end

--- a/src/types/local.jl
+++ b/src/types/local.jl
@@ -1,8 +1,8 @@
 """
-    struct LocalCartesian{T} <: LengthCartesian{T, 3}
+    struct LocalCartesian{T} <: AbstractLocalPosition{T, 3}
 Represents a position in a generic local CRS. 
 
-# Fields
+# Properties
 - `x::Met{T}`: X-coordinate in meters
 - `y::Met{T}`: Y-coordinate in meters
 - `z::Met{T}`: Z-coordinate in meters
@@ -20,27 +20,27 @@ All subtypes of `P <: AbstractSatcomCoordinate` can also be constructed using a 
 
 See also: [`GeneralizedSpherical`](@ref).
 """
-struct LocalCartesian{T} <: LengthCartesian{T, 3}
-    x::Met{T}
-    y::Met{T}
-    z::Met{T}
+struct LocalCartesian{T} <: AbstractLocalPosition{T, 3}
+    svector::SVector{3, T}
 
-    BasicTypes.constructor_without_checks(::Type{LocalCartesian{T}}, x, y, z) where T = new{T}(x, y, z)
+    BasicTypes.constructor_without_checks(::Type{LocalCartesian{T}}, svector::SVector{3, T}) where T = new{T}(svector)
 end
 
 
 """
-    struct GeneralizedSpherical{T, P <: AbstractPointing{T}} <: AngleAngleDistance{T}
+    struct GeneralizedSpherical{T, P <: AngularPointing} <: AbstractPosition{T, 3}
 Represents a position in a local CRS, defined by an angular pointing direction and a distance.
 
-# Fields
-- `pointing::P`: The pointing direction of the object
+!!! note
+    The parameter `P` should not be a concrete type of angular pointing but a basic subtype without the `numbertype` parameter, e.g. `AzEl` instead of `AzEl{Float64}`.
+
+# Properties
+- `angle1::Deg{T}`: First angle of the referenced angular pointing CRS `P`. The name of the property is actually not `angle1` but will be the first property of objects of type `P`
+- `angle2::Deg{T}`: Second angle of the referenced angular pointing CRS `P`. The name of the property is actually not `angle2` but will be the second property of objects of type `P`
 - `r::Met{T}`: The distance of the object from the origin of the CRS
 
-The `r` field can also be accessed via `getproperty` using the `distance` alias:
-
 # Basic Constructors
-    PointingAndDistance(pointing::P, r::ValidDistance)
+    PointingAndDistance(pointing::AngularPointing, r::ValidDistance)
 
 `ValidDistance` is either a Real Number, or a subtype of `Unitful.Length`.
 
@@ -48,9 +48,8 @@ If of the provided argument is `NaN`, the returned `PointingAndDistance` object 
 
 See also: [`Spherical`](@ref), [`AzElDistance`](@ref), [`LocalCartesian`](@ref).
 """
-struct GeneralizedSpherical{T, P <: AbstractPointing{T}} <: AngleAngleDistance{T}
-    pointing::P
-    r::Met{T}
+struct GeneralizedSpherical{T, P <: AngularPointing} <: AbstractLocalPosition{T, 3}
+    svector::SVector{3, T}
 
-    BasicTypes.constructor_without_checks(::Type{GeneralizedSpherical{T, P}}, pointing, r) where {T, P} = new{T, P}(pointing, r)
+    BasicTypes.constructor_without_checks(::Type{GeneralizedSpherical{T, P}}, svector::SVector{3, T}) where {T, P} = new{T, P}(svector)
 end

--- a/src/types/local.jl
+++ b/src/types/local.jl
@@ -35,12 +35,13 @@ Represents a position in a local CRS, defined by an angular pointing direction a
     The parameter `P` should not be a concrete type of angular pointing but a basic subtype without the `numbertype` parameter, e.g. `AzEl` instead of `AzEl{Float64}`.
 
 # Properties
-- `angle1::Deg{T}`: First angle of the referenced angular pointing CRS `P`. The name of the property is actually not `angle1` but will be the first property of objects of type `P`
-- `angle2::Deg{T}`: Second angle of the referenced angular pointing CRS `P`. The name of the property is actually not `angle2` but will be the second property of objects of type `P`
+- `angle1::Deg{T}`: First angle of the referenced angular pointing CRS `P`. The name of the property is actually not `angle1` but will be the first property name of objects of type `P`
+- `angle2::Deg{T}`: Second angle of the referenced angular pointing CRS `P`. The name of the property is actually not `angle2` but will be the second property name of objects of type `P`
 - `r::Met{T}`: The distance of the object from the origin of the CRS
 
 # Basic Constructors
-    PointingAndDistance(pointing::AngularPointing, r::ValidDistance)
+    GeneralizedSpherical(pointing::AngularPointing, r::ValidDistance)
+    GeneralizedSpherical{P[, T]}(a1::ValidAngle, a2::ValidAngle, r::ValidDistance)
 
 `ValidDistance` is either a Real Number, or a subtype of `Unitful.Length`.
 

--- a/src/types/pointing.jl
+++ b/src/types/pointing.jl
@@ -6,7 +6,7 @@ are the `x`, `y`, and `z` components of the unit vector and can also be seen as
 the `u`, `v`, and `w` direction cosines of the direction identified by the
 `PointingVersor` instance.
 
-# Fields
+# Properties
 - `x::T`: The component along the X axis of the corresponding reference frame. Can also be accessed with the `u` property name.
 - `y::T`: The component along the Y axis of the corresponding reference frame. Can also be accessed with the `v` property name.
 - `z::T`: The component along the Z axis of the corresponding reference frame. Can also be accessed with the `w` property name.
@@ -14,11 +14,9 @@ the `u`, `v`, and `w` direction cosines of the direction identified by the
 See also: [`UV`](@ref), [`ThetaPhi`](@ref), [`AzOverEl`](@ref), [`ElOverAz`](@ref)
 """
 struct PointingVersor{T} <: AbstractPointing{T}
-    x::T
-    y::T
-    z::T
+    svector::SVector{3, T}
 
-    BasicTypes.constructor_without_checks(::Type{PointingVersor{T}}, x, y, z) where T = new{T}(x, y, z)
+    BasicTypes.constructor_without_checks(::Type{PointingVersor{T}}, svector::SVector{3, T}) where T = new{T}(svector)
 end
 
 # UV
@@ -37,7 +35,7 @@ representation](https://en.wikipedia.org/wiki/Spherical_coordinate_system) by th
 !!! note
     The inputs values must also satisfy `u^2 + v^2 <= 1 + SatcomCoordinates.UV_CONSTRUCTOR_TOLERANCE[]` or an error will be thrown. The `SatcomCoordinates.UV_CONSTRUCTOR_TOLERANCE` is a `Ref{Float64}` which defaults to 1e-5 (In case `u^2 + v^2 > 1` the inputs are normalized to ensure `u^2 + v^2 = 1`).
 
-# Fields
+# Properties
 - `u::T`
 - `v::T`
 
@@ -55,9 +53,9 @@ which will internally call the 2-arguments constructor.
 See also: [`PointingVersor`](@ref), [`ThetaPhi`](@ref)
 """
 struct UV{T} <: AbstractPointing{T}
-    u::T
-    v::T
-    BasicTypes.constructor_without_checks(::Type{UV{T}}, u, v) where {T} = new{T}(u, v)
+    svector::SVector{2, T}
+
+    BasicTypes.constructor_without_checks(::Type{UV{T}}, svector::SVector{2, T}) where {T} = new{T}(svector)
 end
 
 # ThetaPhi
@@ -73,7 +71,7 @@ Assuming `u`, `v`, and `w` to be direction cosines of the pointing versor `̂p`,
 - `v = sin(θ) * sin(φ)`
 - `w = cos(θ)`
 
-# Fields
+# Properties
 - `θ::Deg{T}`: The so-called `polar angle`, representing the angle between the `Z` axis and the `XY` plane of the reference frame. It is always normalized to fall within the [-90°, 90°] range.
 - `φ::Deg{T}`: The so-called `azimuth angle`, representing the angle between the `y` and `x` component of the pointing direction. It is always normalized to fall within the [-180°, 180°] range.
 
@@ -97,9 +95,9 @@ constructor.
 See also: [`PointingVersor`](@ref), [`UV`](@ref)
 """
 struct ThetaPhi{T} <: AngularPointing{T}
-	θ::Deg{T}
-	φ::Deg{T}
-    BasicTypes.constructor_without_checks(::Type{ThetaPhi{T}}, θ::Deg, φ::Deg) where T = new{T}(θ, φ)
+    svector::SVector{2, T}
+
+    BasicTypes.constructor_without_checks(::Type{ThetaPhi{T}}, svector::SVector{2, T}) where T = new{T}(svector)
 end
 
 ### AzOverEl ###
@@ -118,7 +116,7 @@ Assuming `u`, `v`, and `w` to be direction cosines of the pointing versor `̂p`,
 !!! note
     The equations above are used to represent the "Azimuth over Elevation" coordinates in GRASP. Some textbooks, however, use the opposite convention, meaning that the same equations (with a possible flip in the az/u sign) are used to describe an "Elevation over Azimuth" coordinate system. This is for example the case in the book _"Theory and Practice of Modern Antenna Range Measurements"_ by Clive Parini et al.
 
-# Fields
+# Properties
 - `az::Deg{T}: The azimuth angle in degrees, constrained to be in the [-180°, 180°] range.`
 - `el::Deg{T}: The elevation angle in degrees, constrained to be in the [-90°, 90°] range.`
 
@@ -126,10 +124,9 @@ Assuming `u`, `v`, and `w` to be direction cosines of the pointing versor `̂p`,
     The fields of `AzOverEl` objects can also be accessed via `getproperty` using the `azimuth` and `elevation` aliases.
 """
 struct AzOverEl{T} <: AngularPointing{T}
-    az::Deg{T}
-    el::Deg{T}
+    svector::SVector{2, T}
 
-    BasicTypes.constructor_without_checks(::Type{AzOverEl{T}}, az::Deg, el::Deg) where {T} = new{T}(az, el)
+    BasicTypes.constructor_without_checks(::Type{AzOverEl{T}}, svector::SVector{2, T}) where T = new{T}(svector)
 end
 
 ### ElOverAz ###
@@ -158,10 +155,9 @@ Assuming `u`, `v`, and `w` to be direction cosines of the pointing versor `̂p`,
 See also: [`AzOverEl`](@ref), [`ThetaPhi`](@ref), [`PointingVersor`](@ref), [`UV`](@ref)
 """
 struct ElOverAz{T} <: AngularPointing{T}
-    az::Deg{T}
-    el::Deg{T}
+    svector::SVector{2, T}
 
-    BasicTypes.constructor_without_checks(::Type{ElOverAz{T}}, az::Deg, el::Deg) where T = new{T}(az, el)
+    BasicTypes.constructor_without_checks(::Type{ElOverAz{T}}, svector::SVector{2, T}) where T = new{T}(svector)
 end
 
 """
@@ -186,8 +182,7 @@ Assuming `u`, `v`, and `w` to be direction cosines of the pointing versor `̂p`,
 See also: [`ThetaPhi`](@ref), [`PointingVersor`](@ref), [`UV`](@ref), [`ElOverAz`](@ref), [`AzOverEl`](@ref)
 """
 struct AzEl{T} <: AngularPointing{T}
-    az::Deg{T}
-    el::Deg{T}
+    svector::SVector{2, T}
 
-    BasicTypes.constructor_without_checks(::Type{AzEl{T}}, az::Deg, el::Deg) where T = new{T}(az, el)
+    BasicTypes.constructor_without_checks(::Type{AzEl{T}}, svector::SVector{2, T}) where T = new{T}(svector)
 end

--- a/src/types/pointing_offsets.jl
+++ b/src/types/pointing_offsets.jl
@@ -1,44 +1,13 @@
 """
-    struct UVOffset{T} <: AbstractPointingOffset{T}
+    struct PointingOffset{P, T} <: AbstractPointingOffset{T}
 
-Type used to describe an offset in UV coordinates.
+Type used to describe an offset between two pointing directions.
 
-The UVOffset coordinates must satisfy:
-- `sqrt(u^2 + v^2) ≤ 2`
-
-This type is mostly generated indirectly when subtracting two pointing directions expressed in UV.
+!!! note
+    The `P` parameter must be a subtype of `Union{UV, AngularPointing}` but must be the basic pointing type without specific numbertype (e.g. `UV` rather than `UV{Float64}`) as the numbertype is already tracked by the `T` parameter within the `PointingOffset` type.
 """
-struct UVOffset{T} <: AbstractPointingOffset{T}
-    inner::UV{T}
+struct PointingOffset{P <: Union{UV, AngularPointing}, T} <: AbstractPointingOffset{T}
+    svector::SVector{2, T}
 
-    BasicTypes.constructor_without_checks(::Type{UVOffset{T}}, uv::UV) where T = new{T}(uv)
-
-    function BasicTypes.constructor_without_checks(::Type{UVOffset{T}}, u, v) where T
-        uv = constructor_without_checks(UV{T}, u, v)
-        return constructor_without_checks(UVOffset{T}, uv)
-    end
-end
-
-##### ThetaPhiOffset #####
-
-"""
-    struct ThetaPhiOffset{T} <: AbstractPointingOffset{T}
-
-Type used to describe an angular offset between two pointing directions.
-
-The ThetaPhiOffset coordinates must satisfy:
-- `theta ∈ [-90, 90]`
-- `phi ∈ [-180, 180]`
-
-This type is mostly used with the [`add_angular_offset`](@ref) and [`get_angular_offset`](@ref) functions.
-"""
-struct ThetaPhiOffset{T} <: AbstractPointingOffset{T}
-    inner::ThetaPhi{T}
-
-    BasicTypes.constructor_without_checks(::Type{ThetaPhiOffset{T}}, tp::ThetaPhi) where T = new{T}(tp)
-
-    function BasicTypes.constructor_without_checks(::Type{ThetaPhiOffset{T}}, theta, phi) where T
-        tp = constructor_without_checks(ThetaPhi{T}, theta, phi)
-        return constructor_without_checks(ThetaPhiOffset{T}, tp)
-    end
+    BasicTypes.constructor_without_checks(::Type{PointingOffset{P, T}}, svector::SVector{2, T}) where {P <: Union{UV, AngularPointing}, T} = new{P, T}(svector)
 end

--- a/src/types/topocentric.jl
+++ b/src/types/topocentric.jl
@@ -1,17 +1,12 @@
 """
-    struct ENU{T} <: LengthCartesian{T, 3}
+    struct ENU{T} <: AbstractTopocentricPosition{T}
 Represents a position in the East-North-Up (ENU) coordinate system, which is a local coordinate system centered at a point on or above the surface of an Ellipsoid. 
 The direction of the ENU axes is uniquely determined by the latitude, longitude, and altitude of the point w.r.t. the referenced ellipsoid.
 
-# Fields
+# Properties
 - `x::Met{T}`: X-coordinate in meters
 - `y::Met{T}`: Y-coordinate in meters
 - `z::Met{T}`: Z-coordinate in meters
-
-The fields of `ENU` objects can also be accessed via `getproperty` using the follwing alternative aliases:
-- `east` for `x`
-- `north` for `y`
-- `up` for `z`
 
 # Basic Constructors
     ENU(x::ValidDistance, y::ValidDistance, z::ValidDistance)
@@ -26,28 +21,21 @@ All subtypes of `P <: AbstractSatcomCoordinate` can also be constructed using a 
 
 See also: [`NED`](@ref), [`AER`](@ref).
 """
-struct ENU{T} <: LengthCartesian{T, 3}
-    x::Met{T}
-    y::Met{T}
-    z::Met{T}
+struct ENU{T} <: AbstractTopocentricPosition{T}
+    svector::SVector{3, T}
 
-    BasicTypes.constructor_without_checks(::Type{ENU{T}}, x, y, z) where T = new{T}(x, y, z)
+    BasicTypes.constructor_without_checks(::Type{ENU{T}}, sv::SVector{3, T}) where T = new{T}(sv)
 end
 
 """
-    struct NED{T} <: LengthCartesian{T, 3}
+    struct NED{T} <: AbstractTopocentricPosition{T}
 Represents a position in the North-East-Down (NED) coordinate system, which is a local coordinate system centered at a point on or above the surface of an Ellipsoid. 
 The direction of the NED axes is uniquely determined by the latitude, longitude, and altitude of the point w.r.t. the referenced ellipsoid.
 
-# Fields
+# Properties
 - `x::Met{T}`: X-coordinate in meters
 - `y::Met{T}`: Y-coordinate in meters
 - `z::Met{T}`: Z-coordinate in meters
-
-The fields of `NED` objects can also be accessed via `getproperty` using the follwing alternative aliases:
-- `north` for `x`
-- `east` for `y`
-- `down` for `z`
 
 # Basic Constructors
     NED(x::ValidDistance, y::ValidDistance, z::ValidDistance)
@@ -62,27 +50,20 @@ All subtypes of `P <: AbstractSatcomCoordinate` can also be constructed using a 
 
 See also: [`ENU`](@ref), [`AER`](@ref).
 """
-struct NED{T} <: LengthCartesian{T, 3}
-    x::Met{T}
-    y::Met{T}
-    z::Met{T}
-    BasicTypes.constructor_without_checks(::Type{NED{T}}, x, y, z) where T = new{T}(x, y, z)
+struct NED{T} <: AbstractTopocentricPosition{T}
+    svector::SVector{3, T}
+    BasicTypes.constructor_without_checks(::Type{NED{T}}, sv::SVector{3, T}) where T = new{T}(sv)
 end
 
 """
-    struct AER{T} <: AngleAngleDistance{T}
+    struct AER{T} <: AbstractTopocentricPosition{T}
 Represents a position in the Azimuth-Elevation-Range (AER) coordinate system, which is a local coordinate system centered at a point on or above the surface of an Ellipsoid. 
 The Elevation and Azimuth angles are always defined w.r.t. the ENU CRS with the same origin. More specifically:
 
-# Fields
+# Properties
 - `az::Deg{T}`: Azimuth angle, defined angle in the XY (North-East) plane from the +Y (North) direction to the object, positive towards +X (East) direction. It is constrained to be in the range `[-180°, 180°]`
 - `el::Deg{T}`: Elevation angle, defined as the angle between the XY plane and the point being described by the AER coordinates, positive towards +Z (Up) direction. It is constrained to be in the range `[-90°, 90°]`
 - `r::Met{T}`: Range in meters between the origin of the ENU CRS and the point being described by the AER coordinates.
-
-The fields of `AER` objects can also be accessed via `getproperty` using the follwing alternative aliases:
-- `azimuth` for `az`
-- `elevation` for `el`
-- `range` or `distance` for `r`
 
 # Basic Constructors
     AER(az::ValidAngle, el::ValidAngle, r::ValidDistance)
@@ -97,9 +78,7 @@ All subtypes of `P <: AbstractSatcomCoordinate` can also be constructed using a 
 
 See also: [`ENU`](@ref), [`NED`](@ref).
 """
-struct AER{T} <: AngleAngleDistance{T}
-    az::Deg{T}
-    el::Deg{T}
-    r::Met{T}
-    BasicTypes.constructor_without_checks(::Type{AER{T}}, az, el, r) where T = new{T}(az, el, r)
+struct AER{T} <: AbstractTopocentricPosition{T}
+    svector::SVector{3, T}
+    BasicTypes.constructor_without_checks(::Type{AER{T}}, sv::SVector{3, T}) where T = new{T}(sv)
 end

--- a/src/types/traits.jl
+++ b/src/types/traits.jl
@@ -1,0 +1,3 @@
+abstract type PositionTrait end
+struct CartesianPositionTrait <: PositionTrait end
+struct SphericalPositionTrait <: PositionTrait end

--- a/src/types/transforms.jl
+++ b/src/types/transforms.jl
@@ -19,7 +19,7 @@ struct CRSRotation{T, R <: Rotation{3, T}} <: AbstractCRSRotation{T}
 end
 
 """
-    BasicCRSTransform{T, R <: Union{CRSRotation{T}, Identity}, O <: CartesianPosition{T}} <: AbstractCRSTransform{T}
+    BasicCRSTransform{T, R <: Union{CRSRotation{T}, Identity}, O <: AbstractPosition{T, 3}} <: AbstractCRSTransform{T}
 
 A type representing a basic transformation (rotation + translation).
 
@@ -27,7 +27,7 @@ A type representing a basic transformation (rotation + translation).
 - `rotation::R`: The rotation of the transformation.
 - `origin::O`: The origin of the transformation.
 """
-struct BasicCRSTransform{T, R <: Union{CRSRotation{T}, Identity}, O <: CartesianPosition{T}} <: AbstractAffineCRSTransform{T}
+struct BasicCRSTransform{T, R <: Union{CRSRotation{T}, Identity}, O <: AbstractPosition{T, 3}} <: AbstractAffineCRSTransform{T}
     rotation::R
     origin::O
 end

--- a/src/types/type_aliases.jl
+++ b/src/types/type_aliases.jl
@@ -1,26 +1,10 @@
-### Geocentric
-"""
-    const GeocentricPosition{T} = Union{ECEF{T}, ECI{T}, LLA{T}}
-
-Union of all types that can represent a position in the geocentric coordinate system.
-"""
-const GeocentricPosition{T} = Union{ECEF{T}, ECI{T}, LLA{T}}
-
-### Topocentric
-"""
-    const TopocentricPosition{T} = Union{ENU{T}, NED{T}, AER{T}}
-
-Union of all types that can represent a position in a topocentric coordinate system.
-"""
-const TopocentricPosition{T} = Union{ENU{T}, NED{T}, AER{T}}
-
 ### Generic Local
 """
     const Spherical{T} = GeneralizedSpherical{T, ThetaPhi{T}}
 
 Type representing a position in ISO/Physics spherical coordinates
 """
-const Spherical{T} = GeneralizedSpherical{T, ThetaPhi{T}}
+const Spherical{T} = GeneralizedSpherical{T, ThetaPhi}
 
 """
     const AzElDistance{T} = GeneralizedSpherical{T, AzEl{T}}
@@ -28,16 +12,7 @@ const Spherical{T} = GeneralizedSpherical{T, ThetaPhi{T}}
 Type representing a position w.r.t. a local CRS in Azimuth, Elevation and Range coordinates.
 The difference between `AzElDistance` and [`AER`](@ref) is that `AER` is a always referred to the ENU CRS, while `AzElDistance` is for a generic local CRS.
 """
-const AzElDistance{T} = GeneralizedSpherical{T, AzEl{T}}
-
-"""
-    const GenericLocalPosition{T} = Union{LocalCartesian{T}, GeneralizedSpherical{T}}
-
-Union of all types that can represent a position in a generic local coordinate system.
-"""
-const GenericLocalPosition{T} = Union{LocalCartesian{T}, GeneralizedSpherical{T}}
-
-
+const AzElDistance{T} = GeneralizedSpherical{T, AzEl}
 """
     const ForwardOrInverse{F <: AbstractCRSTransform} = Union{F, InverseTransform{<:Any, <:F}}
 
@@ -51,13 +26,3 @@ const ForwardOrInverse{F <: AbstractCRSTransform} = Union{F, InverseTransform{<:
 Union representing the types defined and exported by this package, which always have a numbertype as first parameter.
 """
 const WithNumbertype{T} = Union{AbstractSatcomCoordinate{T}, AbstractCRSTransform{T}}
-
-# These are const variables used to overload getproperty for specific fields
-const THETA_ALIASES = (:θ, :theta, :t)
-const PHI_ALIASES = (:φ, :ϕ, :phi, :p)
-const AZIMUTH_ALIASES = (:az, :azimuth)
-const ELEVATION_ALIASES = (:el, :elevation)
-const DISTANCE_ALIASES = (:r, :distance, :range)
-const LATITUDE_ALIASES = (:lat, :latitude)
-const LONGITUDE_ALIASES = (:lon, :longitude)
-const ALTITUDE_ALIASES = (:alt, :altitude, :h, :height)

--- a/src/types/type_aliases.jl
+++ b/src/types/type_aliases.jl
@@ -13,6 +13,10 @@ Type representing a position w.r.t. a local CRS in Azimuth, Elevation and Range 
 The difference between `AzElDistance` and [`AER`](@ref) is that `AER` is a always referred to the ENU CRS, while `AzElDistance` is for a generic local CRS.
 """
 const AzElDistance{T} = GeneralizedSpherical{AzEl, T}
+
+const UVOffset{T} = PointingOffset{UV, T}
+const ThetaPhiOffset{T} = PointingOffset{ThetaPhi, T}
+
 """
     const ForwardOrInverse{F <: AbstractCRSTransform} = Union{F, InverseTransform{<:Any, <:F}}
 

--- a/src/types/type_aliases.jl
+++ b/src/types/type_aliases.jl
@@ -29,4 +29,4 @@ const ForwardOrInverse{F <: AbstractCRSTransform} = Union{F, InverseTransform{<:
 
 Union representing the types defined and exported by this package, which always have a numbertype as first parameter.
 """
-const WithNumbertype{T} = Union{AbstractSatcomCoordinate{T}, AbstractCRSTransform{T}}
+const WithNumbertype{T} = Union{AbstractSatcomCoordinate{T}, AbstractCRSTransform{T}, AbstractFieldValue{<:Any, <:Any, T}}

--- a/src/types/type_aliases.jl
+++ b/src/types/type_aliases.jl
@@ -1,18 +1,18 @@
 ### Generic Local
 """
-    const Spherical{T} = GeneralizedSpherical{T, ThetaPhi{T}}
+    const Spherical{T} = GeneralizedSpherical{ThetaPhi, T}
 
 Type representing a position in ISO/Physics spherical coordinates
 """
-const Spherical{T} = GeneralizedSpherical{T, ThetaPhi}
+const Spherical{T} = GeneralizedSpherical{ThetaPhi, T}
 
 """
-    const AzElDistance{T} = GeneralizedSpherical{T, AzEl{T}}
+    const AzElDistance{T} = GeneralizedSpherical{AzEl, T}
 
 Type representing a position w.r.t. a local CRS in Azimuth, Elevation and Range coordinates.
 The difference between `AzElDistance` and [`AER`](@ref) is that `AER` is a always referred to the ENU CRS, while `AzElDistance` is for a generic local CRS.
 """
-const AzElDistance{T} = GeneralizedSpherical{T, AzEl}
+const AzElDistance{T} = GeneralizedSpherical{AzEl, T}
 """
     const ForwardOrInverse{F <: AbstractCRSTransform} = Union{F, InverseTransform{<:Any, <:F}}
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -64,7 +64,7 @@ See also [`numbertype`](@ref), [`enforce_numbertype`](@ref), [`has_numbertype`](
 """
 function default_numbertype(args::Vararg{Any, N}) where N
     T = promote_type(map(numbertype, args)...)
-    T <: AbstractFloat ? T : Float64
+    return to_valid_numbertype(T)
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -104,7 +104,7 @@ Function that takes as input two angles representing two orthogonal angular comp
 !!! note
     This function already assumes that the provided input angles are already normalized such that both are in the [-180°, 180°] range. If you want to normalize the inputs automatically use the `wrap_first_angle` function.
 """
-wrap_spherical_angles_normalized(az::T, el::T, ::Type{<:Union{AzOverEl, ElOverAz, AzEl}}) where {T <: Deg{<:Real}} =
+wrap_spherical_angles_normalized(az::T, el::T, ::Type{<:Union{AzOverEl, ElOverAz, AzEl, AER}}) where {T <: Deg{<:Real}} =
     ifelse(
         abs(el) <= 90°,  # Condition
         (az, el), # Azimuth angle is already between -180° and 180° as it's already been normalized
@@ -128,8 +128,8 @@ Function that takes as input two angles representing two orthogonal angular comp
 
 !!! 
 """
-wrap_spherical_angles(α::ValidAngle, β::ValidAngle, ::Type{T}) where T <: Union{ThetaPhi, AzOverEl, ElOverAz} = wrap_spherical_angles_normalized(to_degrees(α, RoundNearest), to_degrees(β, RoundNearest), T)
-wrap_spherical_angles(p::Point2D, ::Type{T}) where T <: Union{ThetaPhi, AzOverEl, ElOverAz} = wrap_spherical_angles(p[1], p[2], T)
+wrap_spherical_angles(α::ValidAngle, β::ValidAngle, ::Type{T}) where T <: Union{ThetaPhi, AzOverEl, ElOverAz, AER} = wrap_spherical_angles_normalized(to_degrees(α, RoundNearest), to_degrees(β, RoundNearest), T)
+wrap_spherical_angles(p::Point2D, ::Type{T}) where T <: Union{ThetaPhi, AzOverEl, ElOverAz, AER} = wrap_spherical_angles(p[1], p[2], T)
 
 ##### TO MOVE
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -130,7 +130,3 @@ Function that takes as input two angles representing two orthogonal angular comp
 """
 wrap_spherical_angles(α::ValidAngle, β::ValidAngle, ::Type{T}) where T <: Union{ThetaPhi, AzOverEl, ElOverAz, AER} = wrap_spherical_angles_normalized(to_degrees(α, RoundNearest), to_degrees(β, RoundNearest), T)
 wrap_spherical_angles(p::Point2D, ::Type{T}) where T <: Union{ThetaPhi, AzOverEl, ElOverAz, AER} = wrap_spherical_angles(p[1], p[2], T)
-
-##### TO MOVE
-
-const WithNumbertype{T} = Union{AbstractSatcomCoordinate{T}, AbstractCRSTransform{T}}

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -1,6 +1,6 @@
 @testsnippet setup_extensions begin
     using SatcomCoordinates
-    using SatcomCoordinates: normalized_properties, normalized_svector
+    using SatcomCoordinates: raw_properties, raw_svector
     using Test
     using TestAllocations
 end
@@ -40,10 +40,10 @@ end
     @test ecef_to_geodetic(rand(ECEF{Float32}), ellipsoid=e) isa LLA{Float32}
 
     # Some test for specific values
-    ecef = geodetic_to_ecef(LLA(0,0,0)) |> normalized_svector
+    ecef = geodetic_to_ecef(LLA(0,0,0)) |> raw_svector
     @test ecef ≈ [WGS84_ELLIPSOID.a, 0, 0]
 
-    ecef = geodetic_to_ecef(LLA(90,0,0)) |> normalized_svector
+    ecef = geodetic_to_ecef(LLA(90,0,0)) |> raw_svector
     @test ecef ≈ [0, 0, WGS84_ELLIPSOID.b]
 
     # Test some random fwd and rtn equivalence

--- a/test/fieldvalues.jl
+++ b/test/fieldvalues.jl
@@ -1,6 +1,8 @@
 @testsnippet setup_fieldvalues begin
     using SatcomCoordinates
     using SatcomCoordinates.Unitful
+    using SatcomCoordinates.Unitful
+    using SatcomCoordinates.BasicTypes
     using SatcomCoordinates.StaticArrays
     using Test
     using TestAllocations
@@ -12,42 +14,46 @@ end
 
     const V{T} = Quantity{T, D, U}
 
-    struct VelocityFieldValue{T, CRS <: CartesianPosition{T, 3}} <: AbstractFieldValue{T, 3, CRS, V{T}}
-        svector::SVector{3, V{T}}
+    struct VelocityFieldValue{CRS <: AbstractPosition{<:Any, 3}, T} <: AbstractFieldValue{U, CRS, T}
+        svector::SVector{3, T}
+
+        BasicTypes.constructor_without_checks(::Type{VelocityFieldValue{CRS, T}}, sv::SVector{3, T}) where {CRS, T} = new{CRS, T}(sv)
     end
 
-    sv = map(x -> x * u"m/s", SVector{3, Float64}(1, 2, 3))
+    @test_throws "must not contain the numbertype"  VelocityFieldValue{ECEF{Float64}}(1,2,3)
+    @test_throws "but should have 3 elements"  VelocityFieldValue{ECEF}(1,2,3, 4)
 
-    fv = VelocityFieldValue{Float64, ECEF{Float64}}(sv)
+    fv = VelocityFieldValue{ECEF}(1, 2, 3)
 
     @test fv.x == 1u"m/s"
     @test fv.y == 2u"m/s"
     @test fv.z == 3u"m/s"
-    @test fv.svector == sv
 
-    @test raw_svector(fv) == map(ustrip, sv)
+    @test raw_svector(fv) == SVector{3, Float64}(1, 2, 3)
+    @test raw_properties(fv) == (x=1, y=2, z=3)
 
-    struct ComplexFieldValue{T, CRS <: AbstractPosition{T, 3}} <: AbstractFieldValue{T, 3, CRS, Complex{T}}
-        svector::SVector{3, Complex{T}}
+    struct ComplexUnitlessFieldValue{CRS <: AbstractPosition{<:Any, 3}, T <: Complex} <: AbstractFieldValue{typeof(NoUnits), CRS, T}
+        svector::SVector{3, T}
+
+        BasicTypes.constructor_without_checks(::Type{ComplexUnitlessFieldValue{CRS, T}}, sv::SVector{3, T}) where {CRS, T <: Complex} = new{CRS, T}(sv)
     end
 
+    SatcomCoordinates.enforce_numbertype(C::Type{<:ComplexUnitlessFieldValue}) = enforce_numbertype(C, Complex{Float64})
+
     svu = @SVector rand(Complex{Float64}, 3)
-    fvu = ComplexFieldValue{Float64, Spherical{Float64}}(svu)
+    fvu = ComplexUnitlessFieldValue{Spherical}(svu)
 
     @test raw_svector(fvu) == svu
 
-    @test fvu.θ == fvu.theta == svu[1]
-    @test fvu.ϕ == fvu.phi == svu[2]
-    @test fvu.r == fvu.range == svu[3]
-    @test fvu.svector == svu
+    @test fvu.θ  == svu[1]
+    @test fvu.φ  == svu[2]
+    @test fvu.r  == svu[3]
 
     @testset "Allocations" begin
         @test @nallocs(raw_svector(fv)) == 0
         @test @nallocs(getproperty(fv, :x)) == 0
-        @test @nallocs(getproperty(fv, :svector)) == 0
 
         @test @nallocs(raw_svector(fvu)) == 0
         @test @nallocs(getproperty(fvu, :θ)) == 0
-        @test @nallocs(getproperty(fvu, :svector)) == 0
     end
 end

--- a/test/fieldvalues.jl
+++ b/test/fieldvalues.jl
@@ -25,7 +25,7 @@ end
     @test fv.z == 3u"m/s"
     @test fv.svector == sv
 
-    @test normalized_svector(fv) == map(ustrip, sv)
+    @test raw_svector(fv) == map(ustrip, sv)
 
     struct ComplexFieldValue{T, CRS <: AbstractPosition{T, 3}} <: AbstractFieldValue{T, 3, CRS, Complex{T}}
         svector::SVector{3, Complex{T}}
@@ -34,7 +34,7 @@ end
     svu = @SVector rand(Complex{Float64}, 3)
     fvu = ComplexFieldValue{Float64, Spherical{Float64}}(svu)
 
-    @test normalized_svector(fvu) == svu
+    @test raw_svector(fvu) == svu
 
     @test fvu.θ == fvu.theta == svu[1]
     @test fvu.ϕ == fvu.phi == svu[2]
@@ -42,11 +42,11 @@ end
     @test fvu.svector == svu
 
     @testset "Allocations" begin
-        @test @nallocs(normalized_svector(fv)) == 0
+        @test @nallocs(raw_svector(fv)) == 0
         @test @nallocs(getproperty(fv, :x)) == 0
         @test @nallocs(getproperty(fv, :svector)) == 0
 
-        @test @nallocs(normalized_svector(fvu)) == 0
+        @test @nallocs(raw_svector(fvu)) == 0
         @test @nallocs(getproperty(fvu, :θ)) == 0
         @test @nallocs(getproperty(fvu, :svector)) == 0
     end

--- a/test/geocentric.jl
+++ b/test/geocentric.jl
@@ -1,5 +1,5 @@
 @testsnippet setup_geocentric begin
-    using SatcomCoordinates: numbertype, normalized_svector, normalized_properties, @u_str
+    using SatcomCoordinates: numbertype, raw_svector, raw_properties, @u_str
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes

--- a/test/geocentric.jl
+++ b/test/geocentric.jl
@@ -51,11 +51,11 @@ end
     @test rand(LLA) ≉ rand(LLA)
 
     lla = rand(LLA)
-    @test lla.lat == lla.latitude
-    @test lla.lon == lla.longitude
-    @test lla.alt == lla.altitude == lla.h == lla.height
+    @test lla.lat isa Deg
+    @test lla.lon isa Deg
+    @test lla.alt isa Met
 
-    @test_throws "do not have a property" rand(LLA).q
+    @test_throws "not a valid property" lla.q
 
     @testset "Allocations" begin
         @test @nallocs(LLA(0,0,700km)) == 0

--- a/test/local.jl
+++ b/test/local.jl
@@ -1,6 +1,6 @@
 @testsnippet setup_local begin
     using SatcomCoordinates
-    using SatcomCoordinates: numbertype, normalized_svector, normalized_properties, @u_str, has_pointingtype, pointing_type
+    using SatcomCoordinates: numbertype, raw_svector, raw_properties, @u_str, has_pointingtype, pointing_type
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes
@@ -34,8 +34,8 @@ end
     end
 
     c1, c2 = rand(LocalCartesian, 2)
-    @test normalized_svector(c1 + c2) == normalized_svector(c1) + normalized_svector(c2)
-    @test normalized_svector(c1 - c2) == normalized_svector(c1) - normalized_svector(c2)
+    @test raw_svector(c1 + c2) == raw_svector(c1) + raw_svector(c2)
+    @test raw_svector(c1 - c2) == raw_svector(c1) - raw_svector(c2)
 
     c3 = rand(LocalCartesian{Float32})
     @test c1 + c3 isa LocalCartesian{Float64}
@@ -72,8 +72,8 @@ end
         @test @nallocs(getproperty(rand(Spherical), :theta)) == 0
         @test @nallocs(getproperty(rand(Spherical), :phi)) == 0
 
-        @test @nallocs(normalized_properties(rand(Spherical))) == 0
-        @test @nallocs(normalized_properties(rand(AzElDistance))) == 0
+        @test @nallocs(raw_properties(rand(Spherical))) == 0
+        @test @nallocs(raw_properties(rand(AzElDistance))) == 0
     end
 
     @test GeneralizedSpherical{Float32}(rand(ThetaPhi), rand()) isa Spherical{Float32}
@@ -96,7 +96,7 @@ end
     @test pointing_type(GeneralizedSpherical{Float64, ThetaPhi{Float64}}) == ThetaPhi{Float64}
 
     p = rand(Spherical)
-    @test normalized_properties(p) isa NamedTuple{(:θ, :φ, :r), Tuple{Float64, Float64, Float64}}
+    @test raw_properties(p) isa NamedTuple{(:θ, :φ, :r), Tuple{Float64, Float64, Float64}}
 
     for PT in (ThetaPhi, AzEl, ElOverAz, AzOverEl)
         gs = rand(GeneralizedSpherical{Float64, PT{Float64}})

--- a/test/pointing.jl
+++ b/test/pointing.jl
@@ -1,5 +1,5 @@
 @testsnippet setup_pointing begin
-    using SatcomCoordinates: numbertype, raw_svector
+    using SatcomCoordinates: numbertype, raw_svector, svector_size
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes
@@ -9,6 +9,8 @@ end
 @testitem "PointingVersor" setup=[setup_pointing] begin
     p = PointingVersor(rand(3)...)
     @test norm(raw_svector(p)) ≈ 1
+
+    @test svector_size(PointingVersor) == 3 == svector_size(first(fieldtypes(PointingVersor{Float64})))
 
     @test_throws "is not a valid property" rand(PointingVersor).q
 
@@ -60,6 +62,7 @@ end
     using SatcomCoordinates: UV_CONSTRUCTOR_TOLERANCE
     uv = UV(0,0)
     @test numbertype(uv) == Float64
+    @test svector_size(UV) == 2
     
     @test numbertype(UV{Float32}(1,0)) == Float32
 
@@ -98,6 +101,7 @@ end
 
 @testitem "ThetaPhi" setup=[setup_pointing] begin
     tp = ThetaPhi(0,0)
+    @test svector_size(ThetaPhi) == 2
     @test numbertype(tp) == Float64
     @test tp.θ == 0°
     @test tp.φ == 0°
@@ -187,6 +191,7 @@ end
 
 @testitem "AzOverEl/ElOverAz/AzEl" setup=[setup_pointing] begin
     for P in (AzOverEl, ElOverAz, AzEl)
+        @test svector_size(P) == 2
         p = P(1,2)
         @test numbertype(p) == Float64
         @test p.az == 1°

--- a/test/pointing.jl
+++ b/test/pointing.jl
@@ -1,5 +1,5 @@
 @testsnippet setup_pointing begin
-    using SatcomCoordinates: numbertype, normalized_svector
+    using SatcomCoordinates: numbertype, raw_svector
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes
@@ -8,7 +8,7 @@ end
 
 @testitem "PointingVersor" setup=[setup_pointing] begin
     p = PointingVersor(rand(3)...)
-    @test norm(normalized_svector(p)) ≈ 1
+    @test norm(raw_svector(p)) ≈ 1
 
     @test_throws "do not have a property" rand(PointingVersor).q
 
@@ -23,7 +23,7 @@ end
     p = PointingVersor((0.0, 0, 1f0))
     @test p.z == 1.0 && p.z isa Float64
 
-    @test normalized_svector(-p) == -normalized_svector(p)
+    @test raw_svector(-p) == -raw_svector(p)
 
     # Test some randomness properties
     @testset "rand" begin

--- a/test/pointing.jl
+++ b/test/pointing.jl
@@ -10,7 +10,7 @@ end
     p = PointingVersor(rand(3)...)
     @test norm(raw_svector(p)) ≈ 1
 
-    @test_throws "do not have a property" rand(PointingVersor).q
+    @test_throws "is not a valid property" rand(PointingVersor).q
 
     # Specifying numbertype
     p = PointingVersor{Float32}(rand(3)...)
@@ -51,7 +51,7 @@ end
 
         p = rand(PointingVersor)
         # Check that custom getproperty does not allocate
-        f(p) = (p.x, p.y, p.z, p.u, p.v, p.w)
+        f(p) = (p.x, p.y, p.z)
         @test @nallocs(f(p)) == 0
     end
 end
@@ -99,16 +99,17 @@ end
 @testitem "ThetaPhi" setup=[setup_pointing] begin
     tp = ThetaPhi(0,0)
     @test numbertype(tp) == Float64
-    @test tp.θ == tp.theta == tp.t == 0
-    @test tp.φ == tp.phi == tp.p == 0
+    @test tp.θ == 0°
+    @test tp.φ == 0°
     @test tp.θ isa Deg{Float64}
+    @test tp.φ isa Deg{Float64}
 
-    @test_throws "do not have a property" rand(ThetaPhi).q
+    @test_throws "is not a valid property" rand(ThetaPhi).q
 
     tp = ThetaPhi{Float32}(1,0)
     @test numbertype(tp) == Float32
     @test tp.θ isa Deg{Float32}
-    @test tp.θ == 1°
+    @test tp.θ ≈ 1° atol = 1e-6 # We need tolerance as we go store in rad and get deg back from getproperty
 
     @test ThetaPhi(1,0) == ThetaPhi((1,0)) == ThetaPhi(SVector(1,0)) 
 
@@ -146,7 +147,7 @@ end
         @test @nallocs(ThetaPhi(((1,0)))) == 0
         @test @nallocs(ThetaPhi(SVector(1,0))) == 0
 
-        f(tp) = (tp.θ, tp.φ, tp.t, tp.p, tp.theta, tp.phi)
+        f(tp) = (tp.θ, tp.φ)
         @test @nallocs(f(tp)) == 0
     end
 
@@ -188,11 +189,11 @@ end
     for P in (AzOverEl, ElOverAz, AzEl)
         p = P(1,2)
         @test numbertype(p) == Float64
-        @test p.az ==  p.azimuth == 1°
-        @test p.el == p.elevation == 2°
+        @test p.az == 1°
+        @test p.el == 2°
         @test p.az isa Deg{Float64}
 
-        @test_throws "do not have a property" rand(P).q
+        @test_throws "is not a valid property" rand(P).q
 
         # Test constructors with tuple or SVector
         @test P(1,2) == P((1,2)) == P(SVector(1,2))
@@ -393,7 +394,7 @@ end
             fwd_valid =  ae ≈ p
             tp′ = convert(ThetaPhi, ae)
             rtn_valid = tp′ ≈ tp
-            wrap_valid = -180° <= ae.az <= 180° && -180° <= tp.phi <= 180°
+            wrap_valid = -180° <= ae.az <= 180° && -180° <= tp.φ <= 180°
             return fwd_valid && rtn_valid && wrap_valid
         end
     end

--- a/test/pointing_offset.jl
+++ b/test/pointing_offset.jl
@@ -17,7 +17,17 @@ end
 
     @test isnan(UVOffset(Val{NaN}()))
 
+
     @test uv_offset == UVOffset(uv_offset.u, uv_offset.v)
+
+    @test UVOffset(.1,.2) == _from_pointing(UV(.1,.2))
+
+    tpo = ThetaPhiOffset(1,2)
+
+    nt = raw_properties(tpo)
+    @test nt.θ isa Float64 && nt.φ isa Float64
+    @test nt.θ ≈ deg2rad(1)
+    @test nt.φ ≈ deg2rad(2)
 
     tp1, tp2 = rand(ThetaPhi, 2)
     tp_offset = get_angular_offset(tp1, tp2)

--- a/test/pointing_offset.jl
+++ b/test/pointing_offset.jl
@@ -1,6 +1,6 @@
 @testsnippet setup_pointing_offsets begin
     using SatcomCoordinates
-    using SatcomCoordinates: numbertype, raw_svector, raw_properties, @u_str, has_pointingtype, pointing_type, rotation, origin, UVOffset, ThetaPhiOffset
+    using SatcomCoordinates: numbertype, raw_svector, raw_properties, @u_str, has_pointingtype, pointing_type, rotation, origin, UVOffset, ThetaPhiOffset, PointingOffset, _as_pointing, _from_pointing, PointingOffset
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes
@@ -19,10 +19,6 @@ end
 
     @test uv_offset == UVOffset(uv_offset.u, uv_offset.v)
 
-    @test uv_offset.inner isa UV
-    @test uv_offset.inner.u === uv_offset.u
-    @test uv_offset.inner.v === uv_offset.v
-
     tp1, tp2 = rand(ThetaPhi, 2)
     tp_offset = get_angular_offset(tp1, tp2)
     @test tp_offset isa ThetaPhiOffset
@@ -30,16 +26,13 @@ end
 
     @test isnan(ThetaPhiOffset(Val{NaN}()))
 
-    @test tp_offset.inner isa ThetaPhi
-    @test tp_offset.inner.θ === tp_offset.t === tp_offset.θ
-    @test tp_offset.inner.φ === tp_offset.p === tp_offset.φ
+    @test tp_offset.θ isa Deg
+    @test tp_offset.φ isa Deg
 
     @test rand(UVOffset) isa UVOffset
     @test rand(ThetaPhiOffset) isa ThetaPhiOffset
     @test rand(UVOffset{Float32}) isa UVOffset{Float32}
     @test rand(ThetaPhiOffset{Float32}) isa ThetaPhiOffset{Float32}
-
-    @test tp_offset == ThetaPhiOffset(tp_offset.t, tp_offset.p) == constructor_without_checks(ThetaPhiOffset{Float64}, tp_offset.t, tp_offset.p)
 end
 
 @testitem "angular distance/offset" setup=[setup_pointing_offsets] begin

--- a/test/pointing_offset.jl
+++ b/test/pointing_offset.jl
@@ -1,6 +1,6 @@
 @testsnippet setup_pointing_offsets begin
     using SatcomCoordinates
-    using SatcomCoordinates: numbertype, normalized_svector, normalized_properties, @u_str, has_pointingtype, pointing_type, rotation, origin, UVOffset, ThetaPhiOffset
+    using SatcomCoordinates: numbertype, raw_svector, raw_properties, @u_str, has_pointingtype, pointing_type, rotation, origin, UVOffset, ThetaPhiOffset
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -12,7 +12,7 @@ end
     s = repr(rand(AzElDistance))
     @test contains(s, "AzElDistance")
 
-    s = repr(rand(GeneralizedSpherical{Float64, AzOverEl{Float64}}))
+    s = repr(rand(GeneralizedSpherical{AzOverEl, Float64}))
     @test contains(s, "AzOverEl")
 
     s = repr(MIME"text/plain"(), rand(ECEF))

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -30,6 +30,12 @@ end
     @test contains(s, "ThetaPhi Pointing")
     @test contains(s, "θ = ")
 
+    s = repr(MIME"text/plain"(), rand(PointingVersor))
+    @test contains(s, "PointingVersor")
+    @test contains(s, "x = ")
+    @test contains(s, "y = ")
+    @test contains(s, "z = ")
+
     s = repr(MIME"text/plain"(), rand(UVOffset))
     @test contains(s, "UV Pointing Offset")
     @test contains(s, "u = ")

--- a/test/topocentric.jl
+++ b/test/topocentric.jl
@@ -13,7 +13,7 @@ end
 
         @test P(1,2,3) == P((1,2,3)) == P(SA[1,2,3])
 
-        @test_throws "do not have a property" rand(P).q
+        @test_throws "is not a valid property" rand(P).q
 
         @test rand(P) isa P{Float64}
         @test rand(P{Float32}) isa P{Float32}
@@ -38,14 +38,14 @@ end
     @test_throws "Cannot add coordinates" ENU(1,2,3) + NED(1,2,3)
 
     enu = rand(ENU)
-    @test enu.x === enu.east
-    @test enu.y === enu.north
-    @test enu.z === enu.up
+    @test enu.x isa Met
+    @test enu.y isa Met
+    @test enu.z isa Met
 
     ned = rand(NED)
-    @test ned.x === ned.north
-    @test ned.y === ned.east
-    @test ned.z === ned.down
+    @test ned.x isa Met
+    @test ned.y isa Met
+    @test ned.z isa Met
 
     @testset "Allocations" begin
         @test @nallocs(ENU(1,2,3)) == 0
@@ -64,15 +64,15 @@ end
 
     @test AER(190°, 90, 1000u"m") == AER(-170°, 90°, 1000u"m")
 
-    @test_throws "do not have a property" rand(AER).q
+    @test_throws "is not a valid property" rand(AER).q
 
     @test rand(AER) ≉ rand(AER)
     aer = rand(AER)
     @test aer ≈ aer
 
-    @test aer.azimuth == aer.az
-    @test aer.elevation == aer.el
-    @test aer.range == aer.r
+    @test aer.az isa Deg{Float64}
+    @test aer.el isa Deg{Float64}
+    @test aer.r isa Met{Float64}
 
     ae = rand(AER)
     @test convert(ENU, -ae) ≈ -convert(ENU, ae)

--- a/test/topocentric.jl
+++ b/test/topocentric.jl
@@ -1,5 +1,5 @@
 @testsnippet setup_topocentric begin
-    using SatcomCoordinates: numbertype, normalized_svector, normalized_properties, @u_str
+    using SatcomCoordinates: numbertype, raw_svector, raw_properties, @u_str
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes
@@ -28,8 +28,8 @@ end
         @test p1 ≈ convert(P{Float32}, p1)
 
         c1, c2 = rand(P, 2)
-        @test normalized_svector(c1 + c2) == normalized_svector(c1) + normalized_svector(c2)
-        @test normalized_svector(c1 - c2) == normalized_svector(c1) - normalized_svector(c2)
+        @test raw_svector(c1 + c2) == raw_svector(c1) + raw_svector(c2)
+        @test raw_svector(c1 - c2) == raw_svector(c1) - raw_svector(c2)
 
         c3 = rand(P{Float32})
         @test c1 + c3 isa P{Float64}

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -1,6 +1,6 @@
 @testsnippet setup_transforms begin
     using SatcomCoordinates
-    using SatcomCoordinates: numbertype, normalized_svector, normalized_properties, @u_str, has_pointingtype, pointing_type, rotation, origin, AbstractCRSRotation
+    using SatcomCoordinates: numbertype, raw_svector, raw_properties, @u_str, has_pointingtype, pointing_type, rotation, origin, AbstractCRSRotation
     using SatcomCoordinates.LinearAlgebra
     using SatcomCoordinates.StaticArrays
     using SatcomCoordinates.BasicTypes

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,5 @@
 @testitem "numbertype" begin
-    using SatcomCoordinates: numbertype, has_numbertype, enforce_numbertype
+    using SatcomCoordinates: numbertype, has_numbertype, enforce_numbertype, to_valid_numbertype
     using SatcomCoordinates.Unitful
     using SatcomCoordinates.StaticArrays
 
@@ -12,13 +12,16 @@
     @test numbertype(1u"°") == Int
     @test numbertype(1.0u"°") == Float64
     @test numbertype(1f0) == Float32
-    @test_throws "The numbertype function is not implemented" numbertype(1im)
+    @test_throws "not implemented" numbertype(NoUnits)
     @test_throws "numbertype parameter specified" numbertype(UV)
 
     @test enforce_numbertype(UV) == UV{Float64} # Provide a default as not present in input type
     @test enforce_numbertype(UV{Float32}) == UV{Float32} # Returns the same input type as it already has a numbertype
     @test enforce_numbertype(UV, Float32) == UV{Float32} # Provide a custom default as not present in input type
     @test enforce_numbertype(UV, 1) == UV{Int64} # Provide a custom default as not present in input type
+
+    @test to_valid_numbertype(Complex{Int}) == Complex{Float64}
+    @test_throws "can not be mapped" to_valid_numbertype(UV)
 end
 
 @testitem "wrap_spherical_angles" begin
@@ -35,13 +38,8 @@ end
 end
 
 @testitem "Misc" begin
-    using SatcomCoordinates: normalize_value, basetype, _convert_different
+    using SatcomCoordinates: basetype, _convert_different
     using Unitful
-    # @test normalize_value(1u"°") == deg2rad(1)
-    # @test normalize_value(1.0u"rad") == 1.0
-    # @test normalize_value(1u"m") == 1
-    # @test normalize_value(1f0) == 1f0
-    # @test normalize_value(1u"km") == 1000
 
     @test basetype(PointingVersor) == PointingVersor
     @test basetype(PointingVersor{Float32}) == PointingVersor

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -37,11 +37,11 @@ end
 @testitem "Misc" begin
     using SatcomCoordinates: normalize_value, basetype, _convert_different
     using Unitful
-    @test normalize_value(1u"°") == deg2rad(1)
-    @test normalize_value(1.0u"rad") == 1.0
-    @test normalize_value(1u"m") == 1
-    @test normalize_value(1f0) == 1f0
-    @test normalize_value(1u"km") == 1000
+    # @test normalize_value(1u"°") == deg2rad(1)
+    # @test normalize_value(1.0u"rad") == 1.0
+    # @test normalize_value(1u"m") == 1
+    # @test normalize_value(1f0) == 1f0
+    # @test normalize_value(1u"km") == 1000
 
     @test basetype(PointingVersor) == PointingVersor
     @test basetype(PointingVersor{Float32}) == PointingVersor


### PR DESCRIPTION
Quite big refactor of how coordinates are represented internally.

We now store the coordinates inside a SVector which store unitless values (and radians for angles) as those are the actual values we want to operato on when transforming coordinates.

The units are actually only created when accessing properties via `getproperty` and are accepted as inputs when constructing coordinates.
This slightly decrease performance of construction of coordinates (unless using `BasicTypes.constructor_without_checks`) but makes other operation potentially slightly more efficients (e.g. any trigonometric function was internally required to convert degrees to radians for performance before)